### PR TITLE
Modified shebangs to be self-consistent in bin/

### DIFF
--- a/bin/gwin
+++ b/bin/gwin
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2016 Christopher M. Biwer
 #

--- a/bin/gwin_extract_samples
+++ b/bin/gwin_extract_samples
@@ -1,4 +1,4 @@
-#! /user/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2017 Collin Capano
 #

--- a/bin/gwin_make_inj_workflow
+++ b/bin/gwin_make_inj_workflow
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2017 Christopher M. Biwer, Alexander Harvey Nitz
 #

--- a/bin/gwin_make_workflow
+++ b/bin/gwin_make_workflow
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2016 Christopher M. Biwer, Alexander Harvey Nitz
 #

--- a/bin/gwin_plot_acceptance_rate
+++ b/bin/gwin_plot_acceptance_rate
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2016 Christopher M. Biwer
 #

--- a/bin/gwin_plot_acf
+++ b/bin/gwin_plot_acf
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2016 Christopher M. Biwer
 #

--- a/bin/gwin_plot_acl
+++ b/bin/gwin_plot_acl
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2016 Christopher M. Biwer
 #

--- a/bin/gwin_plot_gelman_rubin
+++ b/bin/gwin_plot_gelman_rubin
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # Copyright (C) 2017 Christopher M. Biwer
 #
 # This program is free software; you can redistribute it and/or modify it

--- a/bin/gwin_plot_geweke
+++ b/bin/gwin_plot_geweke
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2017 Christopher M. Biwer
 #

--- a/bin/gwin_plot_inj_intervals
+++ b/bin/gwin_plot_inj_intervals
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 """ Plots the fraction of injections with their parameter value recovered
 within a credible interval versus credible interval.
 """

--- a/bin/gwin_plot_inj_recovery
+++ b/bin/gwin_plot_inj_recovery
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 """ Plots the recovered versus injected parameter values from a population
 of injections.
 """

--- a/bin/gwin_plot_movie
+++ b/bin/gwin_plot_movie
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2016 Miriam Cabero Mueller
 #

--- a/bin/gwin_plot_posterior
+++ b/bin/gwin_plot_posterior
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2016 Miriam Cabero Mueller, Collin Capano
 #

--- a/bin/gwin_plot_prior
+++ b/bin/gwin_plot_prior
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2016 Christopher M. Biwer
 #

--- a/bin/gwin_plot_samples
+++ b/bin/gwin_plot_samples
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2016 Christopher M. Biwer
 #

--- a/bin/gwin_table_summary
+++ b/bin/gwin_table_summary
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 # Copyright (C) 2016 Christopher M. Biwer
 #

--- a/bin/run_gwin
+++ b/bin/run_gwin
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/bin/bash
 set -e
 export OMP_NUM_THREADS=1
 `which gwin` $*


### PR DESCRIPTION
This PR modifies the `#!/usr/bin/env python` shebang in scripts under `/bin/` to be self-consistent.