### PR TITLE
Cleaned up (unused) imports and some other trivial things

### DIFF
--- a/bin/gwin
+++ b/bin/gwin
@@ -21,28 +21,20 @@
 import os
 import argparse
 import logging
-import numpy
 import shutil
+
+import numpy
+
 import pycbc
-import pycbc.opt
-import pycbc.weave
 import pycbc.version
-from pycbc import calibration
-from pycbc import distributions
-from pycbc import transforms
-from pycbc import fft
-from pycbc import gate
-import gwin
-from pycbc import psd
-from pycbc import scheme
-from pycbc import strain
-from pycbc import types
-from gwin.io.hdf import InferenceFile, check_integrity
+from pycbc import (calibration, distributions, transforms, fft, gate,
+                   opt, psd, scheme, strain, weave)
 from pycbc.waveform import generator
-from gwin import option_utils
+
+import gwin
+from gwin import (burn_in, option_utils)
+from gwin.io.hdf import InferenceFile
 from gwin.option_utils import validate_checkpoint_files
-from gwin import burn_in
-from pycbc import gate
 
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
@@ -124,11 +116,11 @@ parser.add_argument("--verbose", action="store_true", default=False,
 
 # add module pre-defined options
 fft.insert_fft_option_group(parser)
-pycbc.opt.insert_optimization_option_group(parser)
+opt.insert_optimization_option_group(parser)
 psd.insert_psd_option_group_multi_ifo(parser)
 scheme.insert_processing_option_group(parser)
 strain.insert_strain_option_group_multi_ifo(parser)
-pycbc.weave.insert_weave_option_group(parser)
+weave.insert_weave_option_group(parser)
 gate.add_gate_option_group(parser)
 
 # parse command line
@@ -139,11 +131,11 @@ pycbc.init_logging(opts.verbose)
 
 # verify options are sane
 fft.verify_fft_options(opts, parser)
-pycbc.opt.verify_optimization_options(opts, parser)
+opt.verify_optimization_options(opts, parser)
 #psd.verify_psd_options(opts, parser)
 scheme.verify_processing_options(opts, parser)
 #strain.verify_strain_options(opts, parser)
-pycbc.weave.verify_weave_options(opts, parser)
+weave.verify_weave_options(opts, parser)
 
 # check for the output file
 if os.path.exists(opts.output_file) and not opts.force:

--- a/bin/gwin_extract_samples
+++ b/bin/gwin_extract_samples
@@ -30,9 +30,11 @@ InferenceFile.
 
 import os
 import argparse
-import logging
+
 import numpy
+
 import pycbc
+
 from gwin import option_utils
 from gwin.io.hdf import InferenceFile
 from gwin.io.txt import InferenceTXTFile

--- a/bin/gwin_plot_acceptance_rate
+++ b/bin/gwin_plot_acceptance_rate
@@ -17,12 +17,15 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import argparse
-import h5py
 import logging
-import matplotlib as mpl; mpl.use("Agg")
-import matplotlib.pyplot as plt
 import sys
+
+from matplotlib import use
+use('agg')
+from matplotlib import pyplot as plt
+
 from pycbc import results
+
 from gwin.io.hdf import InferenceFile
 
 # command line usage

--- a/bin/gwin_plot_acf
+++ b/bin/gwin_plot_acf
@@ -17,14 +17,16 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import argparse
-import h5py
-import pycbc
 import logging
-import matplotlib as mpl; mpl.use("Agg")
-import matplotlib.pyplot as plt
-import numpy
 import sys
+
+from matplotlib import use
+use('agg')
+from matplotlib import pyplot as plt
+
+import pycbc
 from pycbc import results
+
 from gwin import option_utils
 
 # command line usage

--- a/bin/gwin_plot_acl
+++ b/bin/gwin_plot_acl
@@ -17,15 +17,19 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import argparse
-import h5py
-import pycbc
 import logging
-import matplotlib as mpl; mpl.use("Agg")
-import matplotlib.pyplot as plt
-import numpy
 import sys
+
+import numpy
+
+from matplotlib import use
+use('agg')
+from matplotlib import pyplot as plt
+
+import pycbc
 from pycbc import results
 from pycbc.filter import autocorrelation
+
 from gwin import option_utils
 
 # command line usage

--- a/bin/gwin_plot_inj_intervals
+++ b/bin/gwin_plot_inj_intervals
@@ -6,18 +6,19 @@ within a credible interval versus credible interval.
 import sys
 import argparse
 import logging
-import matplotlib as mpl; mpl.use("Agg")
-import matplotlib.colorbar as cbar
-import matplotlib.pyplot as plt
+
 import numpy
-import pycbc
+
 from scipy import stats
-from matplotlib import cm
-from pycbc import inject
-from pycbc import transforms
+
+from matplotlib import use
+use('agg')
+from matplotlib import pyplot as plt
+
+import pycbc
 from pycbc.results import save_fig_with_metadata
+
 from gwin import option_utils
-from pycbc.io.record import FieldArray
 
 # parse command line
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",

--- a/bin/gwin_plot_movie
+++ b/bin/gwin_plot_movie
@@ -27,20 +27,24 @@
 
 import argparse
 import logging
-import numpy
 import subprocess
 import os
 import glob
-import matplotlib
-matplotlib.use('agg')
-from matplotlib import pyplot
 from multiprocessing import Pool
+
+import numpy
+
+from matplotlib import use
+use('agg')
+from matplotlib import pyplot
+
 import pycbc.results
 from pycbc import transforms
+
 from gwin import option_utils
-from gwin.io.hdf import InferenceFile
-from pycbc.results.scatter_histograms import create_multidim_plot, \
-    get_scale_fac
+from gwin.results.scatter_histograms import (create_multidim_plot,
+                                             get_scale_fac)
+
 
 def integer_logspace(start, end, num):
     """Generates a list of integers that are spaced approximately uniformly

--- a/bin/gwin_plot_posterior
+++ b/bin/gwin_plot_posterior
@@ -28,17 +28,20 @@
 import argparse
 import itertools
 import logging
+import sys
+
 import numpy
-import matplotlib; matplotlib.use("agg")
+
+from matplotlib import (patches, use)
+
 import pycbc
 import pycbc.version
-import sys
-from matplotlib import patches
-from matplotlib import pyplot
-from gwin import option_utils, likelihood
-from gwin.io.hdf import InferenceFile
 from pycbc.results import metadata
 from pycbc.results.scatter_histograms import create_multidim_plot
+
+from gwin import option_utils
+
+use('agg')
 
 # add options to command line
 parser = argparse.ArgumentParser()

--- a/bin/gwin_plot_prior
+++ b/bin/gwin_plot_prior
@@ -16,18 +16,23 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import matplotlib as mpl; mpl.use("Agg")
-import matplotlib.pyplot as plt
 import argparse
-import corner
 import itertools
 import logging
-import numpy
 import sys
-from pycbc import distributions
-import gwin
-from pycbc import results
+
+import numpy
+
+
+from matplotlib import use
+use('agg')
+from matplotlib import pyplot as plt
+
+import corner
+
+from pycbc import (distributions, results)
 from pycbc.workflow import WorkflowConfigParser
+
 
 def cartesian(arrays):
     """ Returns a cartesian product from a list of iterables.

--- a/bin/gwin_plot_samples
+++ b/bin/gwin_plot_samples
@@ -19,15 +19,17 @@
 """
 
 import argparse
-import h5py
 import logging
-import matplotlib as mpl; mpl.use("Agg")
-import matplotlib.pyplot as plt
-import pycbc
-from pycbc import results
-from pycbc import transforms
-from gwin import option_utils
 import sys
+
+from matplotlib import use
+use('agg')
+from matplotlib import pyplot as plt
+
+import pycbc
+from pycbc import (results, transforms)
+
+from gwin import option_utils
 
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",

--- a/bin/gwin_table_summary
+++ b/bin/gwin_table_summary
@@ -17,11 +17,13 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import argparse
-import h5py
 import logging
-import numpy
 import sys
+
+import numpy
+
 from pycbc import results
+
 from gwin import option_utils
 
 # command line usage

--- a/gwin/io/hdf.py
+++ b/gwin/io/hdf.py
@@ -795,5 +795,5 @@ def check_integrity(filename):
         firstidx = tuple([0]*len(ref_shape))
         lastidx = tuple([-1]*len(ref_shape))
         for param in parameters:
-            _ = fp[group.format(param)][firstidx]
-            _ = fp[group.format(param)][lastidx]
+            fp[group.format(param)][firstidx]
+            fp[group.format(param)][lastidx]

--- a/gwin/results/__init__.py
+++ b/gwin/results/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2018  Collin Capano
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""Results utilities for GWIn
+"""

--- a/gwin/sampler/__init__.py
+++ b/gwin/sampler/__init__.py
@@ -25,8 +25,6 @@
 This modules provides a list of implemented samplers for parameter estimation.
 """
 
-import numpy
-
 from .kombine import KombineSampler
 from .emcee import EmceeEnsembleSampler, EmceePTSampler
 from .mcmc import MCMCSampler

--- a/gwin/workflow.py
+++ b/gwin/workflow.py
@@ -17,13 +17,15 @@
 Module that contains functions for setting up the inference workflow.
 """
 
-import logging, os.path
-from pycbc.workflow.core import Executable, FileList, Node, makedir, File, Workflow
-from pycbc.workflow.plotting import PlotExecutable, requirestr, excludestr
-from pycbc.workflow import WorkflowConfigParser
-from itertools import izip_longest
+import logging
+import os.path
+
 from Pegasus import DAX3 as dax
+
+from pycbc.workflow.core import (Executable, FileList, makedir, Workflow)
+from pycbc.workflow.plotting import PlotExecutable
 from pycbc.workflow import pegasus_workflow as wdax
+
 
 def setup_foreground_inference(workflow, coinc_file, single_triggers,
                        tmpltbank_file, insp_segs, insp_data_name,


### PR DESCRIPTION
This PR cleans up the `import` statement blocks in all of the scripts and some of the modules to appease `pyflakes`, and critically adds the missing `gwin.results.__init__` module that prevented the `scatter_histograms` module from being installed.

This change does not introduce (or at least was not intended to introduce) any functional changes in the code.