### PR TITLE
Run --help on all scripts during ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
 before_install:
   - pip install pip setuptools --upgrade
 
+  # install pegasus (don't install dependencies, psycopg2==2.6 is broken)
+  - pip install `grep pegasus requirements.txt` --no-deps
+
 install:
   - python -m pip install .
 
@@ -18,9 +21,12 @@ script:
 
   # run --help on all scripts (just to check for missing imports, etc)
   - |
+    set -e
     for EXE in bin/gwin*; do
+        echo "$ `basename $EXE` --help"
         `basename $EXE` --help 1> /dev/null
     done
+    set +e
 
 after_success:
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ script:
   # run unit tests
   - coverage run ./setup.py test
 
+  # run --help on all scripts (just to check for missing imports, etc)
+  - |
+    for EXE in bin/gwin*; do
+        `basename $EXE` --help 1> /dev/null
+    done
+
 after_success:
   - coverage report
   - coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy
+scipy
+matplotlib
+h5py
+pycbc
+corner
+http://download.pegasus.isi.edu/pegasus/4.8.1/pegasus-python-source-4.8.1.tar.gz#egg=pegasus-wms-4.8.1

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ if set(('test',)).intersection(sys.argv):
     setup_requires.extend(['pytest_runner'])
 
 install_requires = [
+    'numpy',
     'pycbc',
     'matplotlib',
     'scipy',


### PR DESCRIPTION
This PR modifies the CI configuration to run `--help` on all scripts under `bin/`, just to check that we can. This should catch some annoying errors (missing imports, syntax errors, etc).

**NOTE:** the `--help` runs do not contribute to the code coverage, and should not, because just running `--help` doesn't check that anything is correct, just that its not totally broken. 