### PR TITLE
Cleaned style issues with pep8 tool

### DIFF
--- a/gwin/entropy.py
+++ b/gwin/entropy.py
@@ -3,7 +3,9 @@ Kullback-Leibler divergence.
 """
 
 import numpy
+
 from scipy import stats
+
 
 def kl(samples1, samples2, pdf1=False, pdf2=False,
        bins=30, hist_min=None, hist_max=None):
@@ -36,8 +38,8 @@ def kl(samples1, samples2, pdf1=False, pdf2=False,
     hist_range = (hist_min, hist_max)
     if not pdf1:
         samples1, _ = numpy.histogram(samples1, bins=bins,
-                                       range=hist_range, normed=True)
+                                      range=hist_range, normed=True)
     if not pdf2:
         samples2, _ = numpy.histogram(samples2, bins=bins,
-                                   range=hist_range, normed=True)
+                                      range=hist_range, normed=True)
     return stats.entropy(samples1, qk=samples2)

--- a/gwin/gelman_rubin.py
+++ b/gwin/gelman_rubin.py
@@ -18,6 +18,7 @@ diagnostic statistic.
 
 import numpy
 
+
 def walk(chains, start, end, step):
     """ Calculates Gelman-Rubin conervergence statistic along chains of data.
     This function will advance along the chains and calculate the
@@ -59,10 +60,11 @@ def walk(chains, start, end, step):
 
     # loop over end indexes and calculate statistic
     for i, e in enumerate(ends):
-        tmp = chains[:,:,0:e]
+        tmp = chains[:, :, 0:e]
         stats[:, i] = gelman_rubin(tmp)
 
     return starts, ends, stats
+
 
 def gelman_rubin(chains, auto_burn_in=True):
     """ Calculates the univariate Gelman-Rubin convergence statistic
@@ -144,19 +146,25 @@ def gelman_rubin(chains, auto_burn_in=True):
 
     # get V the combined variance of all chains
     # this will have shape (nparameters)
-    v = (niterations - 1.) * w_diag / niterations + (1. + 1. / nchains) * b_diag / niterations
+    v = ((niterations - 1.) * w_diag / niterations +
+         (1. + 1. / nchains) * b_diag / niterations)
 
     # get factors in variance of V calculation
     # this will have shape (nparameters)
     k = 2 * b_diag**2 / (nchains - 1)
-    mid_term = numpy.cov(var, means**2)[nparameters:2 * nparameters, 0:nparameters].T
-    end_term = numpy.cov(var, means)[nparameters:2 * nparameters, 0:nparameters].T
+    mid_term = numpy.cov(
+        var, means**2)[nparameters:2*nparameters, 0:nparameters].T
+    end_term = numpy.cov(
+        var, means)[nparameters:2*nparameters, 0:nparameters].T
     wb = niterations / nchains * numpy.diag(mid_term - 2 * mu_hat * end_term)
 
     # get variance of V
     # this will have shape (nparameters)
-    var_v = ((niterations - 1.)**2 * s + (1. + 1. / nchains)**2 * k + \
-             2. * (niterations - 1.) * (1. + 1. / nchains) * wb) / niterations**2
+    var_v = (
+        (niterations - 1.) ** 2 * s +
+        (1. + 1. / nchains) ** 2 * k +
+        2. * (niterations - 1.) * (1. + 1. / nchains) * wb
+    ) / niterations**2
 
     # get degrees of freedom
     # this will have shape (nparameters)
@@ -177,4 +185,3 @@ def gelman_rubin(chains, auto_burn_in=True):
     psrf = numpy.sqrt(r2_estimate * df_adj)
 
     return psrf
-

--- a/gwin/geweke.py
+++ b/gwin/geweke.py
@@ -18,6 +18,7 @@
 
 import numpy
 
+
 def geweke(x, seg_length, seg_stride, end_idx, ref_start,
            ref_end=None, seg_start=0):
     """ Calculates Geweke conervergence statistic for a chain of data.
@@ -73,8 +74,8 @@ def geweke(x, seg_length, seg_stride, end_idx, ref_start,
         x_start = x[start:x_start_end]
 
         # compute statistic
-        stats.append((x_start.mean() - x_end.mean())
-                     / numpy.sqrt(x_start.var() + x_end.var()))
+        stats.append((x_start.mean() - x_end.mean()) / numpy.sqrt(
+            x_start.var() + x_end.var()))
 
         # store end of first segment
         ends.append(x_start_end)

--- a/gwin/io/txt.py
+++ b/gwin/io/txt.py
@@ -18,6 +18,7 @@ inference samplers generate and are stored in an ASCII TXT file.
 
 import numpy
 
+
 class InferenceTXTFile(object):
     """ A class that has extra functions for handling reading the samples
     from posterior-only TXT files.
@@ -63,4 +64,3 @@ class InferenceTXTFile(object):
         numpy.savetxt(output_file, samples,
                       comments=cls.comments, header=header,
                       delimiter=delimiter)
-

--- a/gwin/results/scatter_histograms.py
+++ b/gwin/results/scatter_histograms.py
@@ -26,26 +26,31 @@
 Module to generate figures with scatter plots and histograms.
 """
 
-import numpy
-import scipy.stats
 import itertools
+import sys
+
+import numpy
+
+import scipy.stats
+
 import matplotlib
+
 # Only if a backend is not already set ... This should really *not* be done
 # here, but in the executables you should set matplotlib.use()
 # This matches the check that matplotlib does internally, but this *may* be
 # version dependenant. If this is a problem then remove this and control from
 # the executables directly.
-import sys
 if 'matplotlib.backends' not in sys.modules:
     matplotlib.use('agg')
-from matplotlib import offsetbox
-from matplotlib import pyplot
-import matplotlib.gridspec as gridspec
+
+from matplotlib import (offsetbox, pyplot, gridspec)
+
 from pycbc.results import str_utils
 from pycbc.io import FieldArray
 
+
 def create_axes_grid(parameters, labels=None, height_ratios=None,
-        width_ratios=None, no_diagonals=False):
+                     width_ratios=None, no_diagonals=False):
     """Given a list of parameters, creates a figure with an axis for
     every possible combination of the parameters.
 
@@ -88,12 +93,13 @@ def create_axes_grid(parameters, labels=None, height_ratios=None,
     fig = pyplot.figure(figsize=fsize)
     # create the axis grid
     gs = gridspec.GridSpec(ndim, ndim, width_ratios=width_ratios,
-        height_ratios=height_ratios, wspace=0.05, hspace=0.05)
+                           height_ratios=height_ratios,
+                           wspace=0.05, hspace=0.05)
     # create grid of axis numbers to easily create axes in the right locations
     axes = numpy.arange(ndim**2).reshape((ndim, ndim))
 
     # Select possible combinations of plots and establish rows and columns.
-    combos =  list(itertools.combinations(parameters, 2))
+    combos = list(itertools.combinations(parameters, 2))
     # add the diagonals
     if not no_diagonals:
         combos += [(p, p) for p in parameters]
@@ -154,9 +160,10 @@ def construct_kde(samples_array, use_kombine=False):
 
 
 def create_density_plot(xparam, yparam, samples, plot_density=True,
-        plot_contours=True, percentiles=None, cmap='viridis',
-        contour_color=None, xmin=None, xmax=None, ymin=None, ymax=None,
-        exclude_region=None, fig=None, ax=None, use_kombine=False):
+                        plot_contours=True, percentiles=None, cmap='viridis',
+                        contour_color=None, xmin=None, xmax=None,
+                        ymin=None, ymax=None, exclude_region=None,
+                        fig=None, ax=None, use_kombine=False):
     """Computes and plots posterior density and confidence intervals using the
     given samples.
 
@@ -238,7 +245,7 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
     if ymax is None:
         ymax = ysamples.max()
     npts = 100
-    X, Y = numpy.mgrid[xmin:xmax:complex(0,npts), ymin:ymax:complex(0,npts)] # pylint:disable=invalid-slice-index
+    X, Y = numpy.mgrid[xmin:xmax:complex(0, npts), ymin:ymax:complex(0, npts)] # pylint:disable=invalid-slice-index
     pos = numpy.vstack([X.ravel(), Y.ravel()])
     if use_kombine:
         Z = numpy.exp(kde(pos.T).reshape(X.shape))
@@ -255,7 +262,7 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
 
     if plot_density:
         ax.imshow(numpy.rot90(Z), extent=[xmin, xmax, ymin, ymax],
-            aspect='auto', cmap=cmap, zorder=1)
+                  aspect='auto', cmap=cmap, zorder=1)
         if contour_color is None:
             contour_color = 'w'
 
@@ -284,9 +291,10 @@ def create_density_plot(xparam, yparam, samples, plot_density=True,
 
 
 def create_marginalized_hist(ax, values, label, percentiles=None,
-        color='k', fillcolor='gray', linecolor='navy',
-        title=True, expected_value=None, expected_color='red',
-        rotated=False, plot_min=None, plot_max=None):
+                             color='k', fillcolor='gray', linecolor='navy',
+                             title=True, expected_value=None,
+                             expected_color='red', rotated=False,
+                             plot_min=None, plot_max=None):
     """Plots a 1D marginalized histogram of the given param from the given
     samples.
 
@@ -353,8 +361,8 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
         values_max = values.max()
         negerror = values_med - values_min
         poserror = values_max - values_med
-        fmt = '$' + str_utils.format_value(values_med, negerror,
-              plus_error=poserror, ndecs=2) + '$'
+        fmt = '${0}$'.format(str_utils.format_value(
+            values_med, negerror, plus_error=poserror, ndecs=2))
 
         if rotated:
             ax.yaxis.set_label_position("right")
@@ -468,17 +476,17 @@ def set_marginal_histogram_title(ax, fmt, color, label=None, rotated=False):
 
 
 def create_multidim_plot(parameters, samples, labels=None,
-                mins=None, maxs=None, expected_parameters=None,
-                expected_parameters_color='r',
-                plot_marginal=True, plot_scatter=True,
-                marginal_percentiles=None, contour_percentiles=None,
-                zvals=None, show_colorbar=True, cbar_label=None,
-                vmin=None, vmax=None, scatter_cmap='plasma',
-                plot_density=False, plot_contours=True,
-                density_cmap='viridis',
-                contour_color=None, hist_color='black',
-                line_color=None, fill_color='gray',
-                use_kombine=False, fig=None, axis_dict=None):
+                         mins=None, maxs=None, expected_parameters=None,
+                         expected_parameters_color='r',
+                         plot_marginal=True, plot_scatter=True,
+                         marginal_percentiles=None, contour_percentiles=None,
+                         zvals=None, show_colorbar=True, cbar_label=None,
+                         vmin=None, vmax=None, scatter_cmap='plasma',
+                         plot_density=False, plot_contours=True,
+                         density_cmap='viridis',
+                         contour_color=None, hist_color='black',
+                         line_color=None, fill_color='gray',
+                         use_kombine=False, fig=None, axis_dict=None):
     """Generate a figure with several plots and histograms.
 
     Parameters
@@ -562,8 +570,8 @@ def create_multidim_plot(parameters, samples, labels=None,
     # if only plotting 2 parameters, make the marginal plots smaller
     nparams = len(parameters)
     if nparams == 2:
-        width_ratios = [3,1]
-        height_ratios = [1,3]
+        width_ratios = [3, 1]
+        height_ratios = [1, 3]
     else:
         width_ratios = height_ratios = None
 
@@ -592,18 +600,18 @@ def create_multidim_plot(parameters, samples, labels=None,
 
     # values for axis bounds
     if mins is None:
-        mins = {p:samples[p].min() for p in parameters}
+        mins = {p: samples[p].min() for p in parameters}
     else:
         # copy the dict
-        mins = {p:val for p,val in mins.items()}
+        mins = {p: val for p, val in mins.items()}
     if maxs is None:
-        maxs = {p:samples[p].max() for p in parameters}
+        maxs = {p: samples[p].max() for p in parameters}
     else:
         # copy the dict
-        maxs = {p:val for p,val in maxs.items()}
+        maxs = {p: val for p, val in maxs.items()}
 
     # remove common offsets
-    for pi,param in enumerate(parameters):
+    for pi, param in enumerate(parameters):
         values, offset = remove_common_offset(samples[param])
         if offset != 0:
             # we'll add the offset removed to the label
@@ -625,10 +633,9 @@ def create_multidim_plot(parameters, samples, labels=None,
             width_ratios=width_ratios, height_ratios=height_ratios,
             no_diagonals=not plot_marginal)
 
-
     # Diagonals...
     if plot_marginal:
-        for pi,param in enumerate(parameters):
+        for pi, param in enumerate(parameters):
             ax, _, _ = axis_dict[param, param]
             # if only plotting 2 parameters and on the second parameter,
             # rotate the marginal plot
@@ -641,7 +648,8 @@ def create_multidim_plot(parameters, samples, labels=None,
                     expected_value = None
             else:
                 expected_value = None
-            create_marginalized_hist(ax, samples[param], label=labels[param],
+            create_marginalized_hist(
+                ax, samples[param], label=labels[param],
                 color=hist_color, fillcolor=fill_color, linecolor=line_color,
                 title=True, expected_value=expected_value,
                 expected_color=expected_parameters_color,
@@ -659,8 +667,8 @@ def create_multidim_plot(parameters, samples, labels=None,
             else:
                 alpha = 1.
             plt = ax.scatter(x=samples[px], y=samples[py], c=zvals, s=5,
-                        edgecolors='none', vmin=vmin, vmax=vmax,
-                        cmap=scatter_cmap, alpha=alpha, zorder=2)
+                             edgecolors='none', vmin=vmin, vmax=vmax,
+                             cmap=scatter_cmap, alpha=alpha, zorder=2)
 
         if plot_contours or plot_density:
             # Exclude out-of-bound regions
@@ -670,13 +678,14 @@ def create_multidim_plot(parameters, samples, labels=None,
                 exclude_region = 'm_s > m_p'
             else:
                 exclude_region = None
-            create_density_plot(px, py, samples, plot_density=plot_density,
-                    plot_contours=plot_contours, cmap=density_cmap,
-                    percentiles=contour_percentiles,
-                    contour_color=contour_color, xmin=mins[px], xmax=maxs[px],
-                    ymin=mins[py], ymax=maxs[py],
-                    exclude_region=exclude_region, ax=ax,
-                    use_kombine=use_kombine)
+            create_density_plot(
+                px, py, samples, plot_density=plot_density,
+                plot_contours=plot_contours, cmap=density_cmap,
+                percentiles=contour_percentiles,
+                contour_color=contour_color, xmin=mins[px], xmax=maxs[px],
+                ymin=mins[py], ymax=maxs[py],
+                exclude_region=exclude_region, ax=ax,
+                use_kombine=use_kombine)
 
         if expected_parameters is not None:
             try:

--- a/gwin/sampler/__init__.py
+++ b/gwin/sampler/__init__.py
@@ -13,26 +13,18 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-
-#
-# =============================================================================
-#
-#                                   Preamble
-#
-# =============================================================================
-#
 """
 This modules provides a list of implemented samplers for parameter estimation.
 """
 
 from .kombine import KombineSampler
-from .emcee import EmceeEnsembleSampler, EmceePTSampler
+from .emcee import (EmceeEnsembleSampler, EmceePTSampler)
 from .mcmc import MCMCSampler
 
 # list of available samplers
-samplers = {
-    KombineSampler.name : KombineSampler,
-    EmceeEnsembleSampler.name : EmceeEnsembleSampler,
-    EmceePTSampler.name : EmceePTSampler,
-    MCMCSampler.name : MCMCSampler,
-}
+samplers = {cls.name: cls for cls in (
+    KombineSampler,
+    EmceeEnsembleSampler,
+    EmceePTSampler,
+    MCMCSampler,
+)}

--- a/gwin/sampler/base.py
+++ b/gwin/sampler/base.py
@@ -51,7 +51,7 @@ def _check_fileformat(read_function):
                             "where FILE.hdf is the name of the file to "
                             "convert to. (Ignore this warning if you are "
                             "doing that now.)\n\n".format(fp.filename,
-                            convert_cmd))
+                                                          convert_cmd))
             # we'll replace cls._read_fields with _read_oldstyle_fields, so
             # that when the read_function calls cls._read_fields, it points
             # to the oldstyle function. First we'll keep a backup copy of
@@ -89,7 +89,7 @@ def _check_aclfileformat(read_function):
                             "where FILE.hdf is the name of the file to "
                             "convert to. (Ignore this warning if you are "
                             "doing that now.)\n\n".format(fp.filename,
-                            convert_cmd))
+                                                          convert_cmd))
             # call oldstyle function instead
             return fp.sampler_class._oldstyle_read_acls(fp)
         else:
@@ -238,7 +238,7 @@ class _BaseSampler(object):
                 val = str(None)
             if isinstance(val, dict):
                 fp.attrs[arg] = val.keys()
-                for key,item in val.items():
+                for key, item in val.items():
                     if item is None:
                         item = str(None)
                     fp.attrs[key] = item
@@ -368,7 +368,7 @@ class BaseMCMCSampler(_BaseSampler):
         # if samples are given then use those as initial positions
         if samples_file is not None:
             samples = self.read_samples(samples_file, self.variable_args,
-                iteration=-1)
+                                        iteration=-1)
             # transform to sampling parameter space
             samples = self.likelihood_evaluator.apply_sampling_transforms(
                 samples)
@@ -413,8 +413,8 @@ class BaseMCMCSampler(_BaseSampler):
         samples = self.chain
         sampling_args = self.sampling_args
         # convert to dictionary to apply boundary conditions
-        samples = {param: samples[...,ii]
-                   for ii,param in enumerate(sampling_args)}
+        samples = {param: samples[..., ii] for
+                   ii, param in enumerate(sampling_args)}
         samples = self.likelihood_evaluator._prior.apply_boundary_conditions(
             **samples)
         # now convert to field array
@@ -422,8 +422,8 @@ class BaseMCMCSampler(_BaseSampler):
                                           for param in sampling_args],
                                          names=sampling_args)
         # apply transforms to go to variable args space
-        return self.likelihood_evaluator.apply_sampling_transforms(samples,
-            inverse=True)
+        return self.likelihood_evaluator.apply_sampling_transforms(
+            samples, inverse=True)
 
     @property
     def likelihood_stats(self):
@@ -519,7 +519,7 @@ class BaseMCMCSampler(_BaseSampler):
                 fp.create_dataset(dataset_name, (nwalkers, istop),
                                   maxshape=(nwalkers, max_iterations),
                                   dtype=float, fletcher32=True)
-            fp[dataset_name][:,istart:istop] = samples[param]
+            fp[dataset_name][:, istart:istop] = samples[param]
 
     def write_chain(self, fp, start_iteration=None, max_iterations=None):
         """Writes the samples from the current chain to the given file.
@@ -652,8 +652,9 @@ class BaseMCMCSampler(_BaseSampler):
 
     @staticmethod
     def _read_oldstyle_fields(fp, fields_group, fields, array_class,
-                     thin_start=None, thin_interval=None, thin_end=None,
-                     iteration=None, walkers=None, flatten=True):
+                              thin_start=None, thin_interval=None,
+                              thin_end=None, iteration=None, walkers=None,
+                              flatten=True):
         """Base function for reading samples and likelihood stats. See
         `read_samples` and `read_likelihood_stats` for details.
 
@@ -973,9 +974,9 @@ class BaseMCMCSampler(_BaseSampler):
         acls = {}
         for param in fp.variable_args:
             samples = cls.read_samples(fp, param,
-                                           thin_start=start_index,
-                                           thin_interval=1, thin_end=end_index,
-                                           flatten=False)[param]
+                                       thin_start=start_index,
+                                       thin_interval=1, thin_end=end_index,
+                                       flatten=False)[param]
             samples = samples.mean(axis=0)
             acl = autocorrelation.calculate_acl(samples)
             if numpy.isinf(acl):

--- a/gwin/sampler/emcee.py
+++ b/gwin/sampler/emcee.py
@@ -34,6 +34,7 @@ from pycbc.filter import autocorrelation
 
 from .base import BaseMCMCSampler, _check_fileformat
 
+
 #
 # =============================================================================
 #
@@ -148,7 +149,7 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
         # generator is set to numpy's after the distributions' rvs functions
         # are called
         super(EmceeEnsembleSampler, self).set_p0(samples_file=samples_file,
-            prior=prior)
+                                                 prior=prior)
         # update the random state
         self._sampler.random_state = numpy.random.get_state()
 
@@ -223,6 +224,7 @@ class EmceeEnsembleSampler(BaseMCMCSampler):
         self.write_acceptance_fraction(fp)
         self.write_state(fp)
 
+
 # This is needed for two reason
 # 1) pools freeze state when created and so classes *cannot be updated*
 # 2) methods cannot be pickled.
@@ -235,6 +237,7 @@ class _callprior(object):
     def __call__(self, args):
         prior = self.callable(args, callfunc='prior')
         return prior if isinstance(prior, numpy.float64) else prior[0]
+
 
 class _callloglikelihood(object):
     """Calls the likelihood function's loglikelihood function.
@@ -386,7 +389,8 @@ class EmceePTSampler(BaseMCMCSampler):
         # if samples are given then use those as initial positions
         if samples_file is not None:
             samples = self.read_samples(samples_file, self.variable_args,
-                iteration=-1, temps='all', flatten=False)[..., 0]
+                                        iteration=-1, temps='all',
+                                        flatten=False)[..., 0]
             # transform to sampling parameter space
             samples = self.likelihood_evaluator.apply_sampling_transforms(
                 samples)
@@ -503,7 +507,7 @@ class EmceePTSampler(BaseMCMCSampler):
 
     @staticmethod
     def write_samples_group(fp, samples_group, parameters, samples,
-                             start_iteration=None, max_iterations=None):
+                            start_iteration=None, max_iterations=None):
         """Writes samples to the given file.
 
         Results are written to:
@@ -561,7 +565,7 @@ class EmceePTSampler(BaseMCMCSampler):
                 fp.create_dataset(dataset_name, (ntemps, nwalkers, istop),
                                   maxshape=(ntemps, nwalkers, max_iterations),
                                   dtype=float, fletcher32=True)
-            fp[dataset_name][:,:,istart:istop] = samples[param]
+            fp[dataset_name][:, :, istart:istop] = samples[param]
 
     def write_results(self, fp, start_iteration=None, max_iterations=None,
                       **metadata):
@@ -595,8 +599,9 @@ class EmceePTSampler(BaseMCMCSampler):
 
     @staticmethod
     def _read_oldstyle_fields(fp, fields_group, fields, array_class,
-                     thin_start=None, thin_interval=None, thin_end=None,
-                     iteration=None, temps=None, walkers=None, flatten=True):
+                              thin_start=None, thin_interval=None,
+                              thin_end=None, iteration=None, temps=None,
+                              walkers=None, flatten=True):
         """Base function for reading samples and likelihood stats. See
         `read_samples` and `read_likelihood_stats` for details.
 
@@ -660,7 +665,6 @@ class EmceePTSampler(BaseMCMCSampler):
                 these_arrays = these_arrays.flatten()
             arrays[name] = these_arrays
         return array_class.from_kwargs(**arrays)
-
 
     @staticmethod
     def _read_fields(fp, fields_group, fields, array_class,
@@ -887,7 +891,7 @@ class EmceePTSampler(BaseMCMCSampler):
                                                end_index=end_index,
                                                per_walker=False, walkers=ii,
                                                parameters=param,
-                                               temps=tk)[param][0,:]
+                                               temps=tk)[param][0, :]
                               for ii in walkers]
                     # we'll stack all of the walker arrays to make a single
                     # nwalkers x niterations array; when these are stacked
@@ -902,7 +906,7 @@ class EmceePTSampler(BaseMCMCSampler):
                                                flatten=False)[param]
                     # contract the walker dimension using the mean, and flatten
                     # the (length 1) temp dimension
-                    samples = samples.mean(axis=1)[0,:]
+                    samples = samples.mean(axis=1)[0, :]
                     thisacf = autocorrelation.calculate_acf(samples).numpy()
                     subacfs.append(thisacf)
             # stack the temperatures
@@ -913,7 +917,7 @@ class EmceePTSampler(BaseMCMCSampler):
                 nw, ni = subacfs[0].shape
                 acfs[param] = numpy.zeros((len(temps), nw, ni), dtype=float)
                 for tk in range(len(temps)):
-                    acfs[param][tk,...] = subacfs[tk]
+                    acfs[param][tk, ...] = subacfs[tk]
             else:
                 acfs[param] = numpy.vstack(subacfs)
         return FieldArray.from_kwargs(**acfs)
@@ -957,7 +961,7 @@ class EmceePTSampler(BaseMCMCSampler):
                                            temps=tk, flatten=False)[param]
                 # contract the walker dimension using the mean, and flatten
                 # the (length 1) temp dimension
-                samples = samples.mean(axis=1)[0,:]
+                samples = samples.mean(axis=1)[0, :]
                 acl = autocorrelation.calculate_acl(samples)
                 if numpy.isinf(acl):
                     acl = samples.size

--- a/gwin/sampler/kombine.py
+++ b/gwin/sampler/kombine.py
@@ -96,7 +96,8 @@ class KombineSampler(BaseMCMCSampler):
         return numpy.mean(self._sampler.acceptance, axis=0)
 
     @classmethod
-    def from_cli(cls, opts, likelihood_evaluator, pool=None, likelihood_call=None):
+    def from_cli(cls, opts, likelihood_evaluator, pool=None,
+                 likelihood_call=None):
         """Create an instance of this sampler from the given command-line
         options.
 
@@ -256,7 +257,7 @@ class KombineSampler(BaseMCMCSampler):
 
         # save clustered KDE data
         subgroup = "clustered_kde"
-        dataset_name ="/".join([fp.sampler_group, subgroup])
+        dataset_name = "/".join([fp.sampler_group, subgroup])
         clustered_kde = self._sampler._kde
         self._write_kde(fp, dataset_name, clustered_kde)
         # metadata
@@ -270,7 +271,6 @@ class KombineSampler(BaseMCMCSampler):
         for i, kde in enumerate(clustered_kde._kdes):
             dataset_name = "/".join([fp.sampler_group, "kde" + str(i)])
             self._write_kde(fp, dataset_name, kde)
-
 
     def set_state_from_file(self, fp):
         """Sets the state of the sampler back to the instance saved in a file.

--- a/gwin/sampler/mcmc.py
+++ b/gwin/sampler/mcmc.py
@@ -21,6 +21,7 @@
 #
 # =============================================================================
 #
+
 """
 This modules provides classes and functions for using a MCMC sampler
 for parameter estimation.
@@ -30,6 +31,7 @@ import numpy
 import logging
 
 from .base import BaseMCMCSampler
+
 
 #
 # =============================================================================
@@ -52,22 +54,22 @@ class MCMCSampler(BaseMCMCSampler):
     def __init__(self, likelihood_evaluator):
         self._chain = []
         self._blobs = []
-        # Using p0 to store the last sample would require to store sparately the
-        # last posterior value.
+        # Using p0 to store the last sample would require to store separately
+        # the last posterior value.
         self._lastsample = []
         self._lastblob = []
         sampler = self
         # initialize
-        super(MCMCSampler, self).__init__(
-              sampler, likelihood_evaluator)
-        self.dtype=numpy.dtype([(name, None) for name in
-                                            ('lnpost',)+self.sampling_args])
+        super(MCMCSampler, self).__init__(sampler, likelihood_evaluator)
+        self.dtype = numpy.dtype([(name, None) for name in
+                                  ('lnpost',) + self.sampling_args])
         # Harcoding the number of walkers to 1.
         # nwalkers should not be a BaseMCMCSampler property.
         self._nwalkers = 1
 
     @classmethod
-    def from_cli(cls, opts, likelihood_evaluator, pool=None, likelihood_call=None):
+    def from_cli(cls, opts, likelihood_evaluator, pool=None,
+                 likelihood_call=None):
         """Create an instance of this sampler from the given command-line
         options.
 
@@ -93,9 +95,9 @@ class MCMCSampler(BaseMCMCSampler):
         additional dimensions are any additional dimensions used by the
         sampler (e.g, walkers, temperatures).
         """
-        #Adding the nwalkers dimention, and converting to an ndarray.
+        # Adding the nwalkers dimention, and converting to an ndarray.
         return self._chain[list(self.sampling_args)].view(numpy.float).reshape(
-                                            (1,) + self._chain.shape + (-1,))
+            (1,) + self._chain.shape + (-1,))
         # Copy needed to avoid numpy 1.13 warning
 
     @property
@@ -103,7 +105,7 @@ class MCMCSampler(BaseMCMCSampler):
         """This function should return the blobs with a shape
         nwalkers x niteration as requested by the BaseMCMCSampler class.
         """
-        #Adding the nwalkers dimention.
+        # Adding the nwalkers dimention.
         return [self._blobs]
 
     def clear_chain(self):
@@ -153,15 +155,15 @@ class MCMCSampler(BaseMCMCSampler):
 
             logging.info("Starting logplr value %f", logplr)
 
-            start_sample = numpy.insert(self.p0,0,logplr)
+            start_sample = numpy.insert(self.p0, 0, logplr)
             start = 0
 
         else:
             start_sample = self._lastsample
-            start = -1 # So restarts do not re-write the same sample.
+            start = -1  # So restarts do not re-write the same sample.
             blob = self._lastblob
 
-        self._chain = numpy.empty(niterations,dtype=self.dtype)
+        self._chain = numpy.empty(niterations, dtype=self.dtype)
         # numpy >=1.14 only accepts tuples
         self._chain[start] = tuple(start_sample)
         self._blobs = [None]*niterations
@@ -187,18 +189,18 @@ class MCMCSampler(BaseMCMCSampler):
                 logplr_prop = result
                 blob = None
 
-            acceptance_ratio=numpy.exp(logplr_prop - logplr_old)
-            u=numpy.random.uniform()
+            acceptance_ratio = numpy.exp(logplr_prop - logplr_old)
+            u = numpy.random.uniform()
             if acceptance_ratio >= u:
-                self._chain[i+1]=numpy.insert(samples_prop,0,logplr_prop)
-                self._blobs[i+1]=blob
+                self._chain[i+1] = numpy.insert(samples_prop, 0, logplr_prop)
+                self._blobs[i+1] = blob
                 logging.info("Step %i, acceptance ratio %f >= %f, accepted",
-                                        i+1, acceptance_ratio, u)
+                             i+1, acceptance_ratio, u)
             else:
-                self._chain[i+1]=self._chain[i]
-                self._blobs[i+1]=self._blobs[i]
+                self._chain[i+1] = self._chain[i]
+                self._blobs[i+1] = self._blobs[i]
                 logging.info("Step %i, acceptance ratio %f < %f, rejected",
-                                        i+1, acceptance_ratio, u)
+                             i+1, acceptance_ratio, u)
 
         self._lastsample = self._chain[-1]
         self._lastblob = self._blobs[-1]

--- a/gwin/workflow.py
+++ b/gwin/workflow.py
@@ -28,8 +28,8 @@ from pycbc.workflow import pegasus_workflow as wdax
 
 
 def setup_foreground_inference(workflow, coinc_file, single_triggers,
-                       tmpltbank_file, insp_segs, insp_data_name,
-                       insp_anal_name, dax_output, out_dir, tags=None):
+                               tmpltbank_file, insp_segs, insp_data_name,
+                               insp_anal_name, dax_output, out_dir, tags=None):
     """ Creates workflow node that will run the inference workflow.
 
     Parameters
@@ -60,9 +60,10 @@ def setup_foreground_inference(workflow, coinc_file, single_triggers,
 
     logging.info("Entering inference module")
 
-    # check if configuration file has inference section    
+    # check if configuration file has inference section
     if not workflow.cp.has_section("workflow-inference"):
-        logging.info("There is no [workflow-inference] section in configuration file")
+        logging.info("There is no [workflow-inference] section in "
+                     "configuration file")
         logging.info("Leaving inference module")
         return
 
@@ -71,10 +72,10 @@ def setup_foreground_inference(workflow, coinc_file, single_triggers,
 
     # make the directory that will contain the dax file
     makedir(dax_output)
-    
+
     # turn the config file into a File class
-    config_path = os.path.abspath(dax_output + "/" + "_".join(tags) \
-                                        + "foreground_gwin.ini")
+    config_path = os.path.abspath(dax_output + "/" + "_".join(tags) +
+                                  "foreground_gwin.ini")
     workflow.cp.write(open(config_path, "w"))
     config_file = wdax.File(os.path.basename(config_path))
     config_file.PFN(config_path, "local")
@@ -91,9 +92,9 @@ def setup_foreground_inference(workflow, coinc_file, single_triggers,
     node.add_multiifo_input_list_opt("--single-detector-triggers",
                                      single_triggers)
     node.new_output_file_opt(workflow.analysis_time, ".dax", "--output-file",
-                                     tags=tags)
+                             tags=tags)
     node.new_output_file_opt(workflow.analysis_time, ".dax.map",
-                                     "--output-map", tags=tags)
+                             "--output-map", tags=tags)
 
     # get dax name and use it for the workflow name
     name = node.output_files[0].name
@@ -110,7 +111,8 @@ def setup_foreground_inference(workflow, coinc_file, single_triggers,
     # and add it to the workflow
     fil = node.output_files[0]
     job = dax.DAX(fil)
-    job.addArguments("--basename %s" % os.path.splitext(os.path.basename(name))[0])
+    job.addArguments(
+        "--basename %s" % os.path.splitext(os.path.basename(name))[0])
     Workflow.set_job_properties(job, map_file)
     workflow._adag.addJob(job)
 
@@ -120,9 +122,10 @@ def setup_foreground_inference(workflow, coinc_file, single_triggers,
 
     logging.info("Leaving inference module")
 
+
 def make_inference_prior_plot(workflow, config_file, output_dir,
-                    sections=None, name="inference_prior",
-                    analysis_seg=None, tags=None):
+                              sections=None, name="inference_prior",
+                              analysis_seg=None, tags=None):
     """ Sets up the corner plot of the priors in the workflow.
 
     Parameters
@@ -147,21 +150,21 @@ def make_inference_prior_plot(workflow, config_file, output_dir,
     Returns
     -------
     pycbc.workflow.FileList
-        A list of result and output files. 
+        A list of result and output files.
     """
 
     # default values
     tags = [] if tags is None else tags
-    analysis_seg = workflow.analysis_time \
-                       if analysis_seg is None else analysis_seg
+    analysis_seg = (workflow.analysis_time if analysis_seg is None else
+                    analysis_seg)
 
     # make the directory that will contain the output files
     makedir(output_dir)
 
     # make a node for plotting the posterior as a corner plot
     node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
-                      out_dir=output_dir, universe="local",
-                      tags=tags).create_node()
+                          out_dir=output_dir, universe="local",
+                          tags=tags).create_node()
 
     # add command line options
     node.add_input_opt("--config-file", config_file)
@@ -175,8 +178,8 @@ def make_inference_prior_plot(workflow, config_file, output_dir,
     return node.output_files
 
 def make_inference_summary_table(workflow, inference_file, output_dir,
-                    variable_args=None, name="inference_table",
-                    analysis_seg=None, tags=None):
+                                 variable_args=None, name="inference_table",
+                                 analysis_seg=None, tags=None):
     """ Sets up the corner plot of the posteriors in the workflow.
 
     Parameters
@@ -201,20 +204,20 @@ def make_inference_summary_table(workflow, inference_file, output_dir,
     Returns
     -------
     pycbc.workflow.FileList
-        A list of result and output files. 
+        A list of result and output files.
     """
 
     # default values
     tags = [] if tags is None else tags
-    analysis_seg = workflow.analysis_time \
-                       if analysis_seg is None else analysis_seg
+    analysis_seg = (workflow.analysis_time if analysis_seg is None else
+                    analysis_seg)
 
     # make the directory that will contain the output files
     makedir(output_dir)
 
     # make a node for plotting the posterior as a corner plot
     node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
-                      out_dir=output_dir, tags=tags).create_node()
+                          out_dir=output_dir, tags=tags).create_node()
 
     # add command line options
     node.add_input_opt("--input-file", inference_file)
@@ -225,6 +228,7 @@ def make_inference_summary_table(workflow, inference_file, output_dir,
     workflow += node
 
     return node.output_files
+
 
 def make_inference_posterior_plot(
                     workflow, inference_file, output_dir, parameters=None,
@@ -253,21 +257,21 @@ def make_inference_posterior_plot(
     Returns
     -------
     pycbc.workflow.FileList
-        A list of result and output files. 
+        A list of result and output files.
     """
 
     # default values
     tags = [] if tags is None else tags
-    analysis_seg = workflow.analysis_time \
-                       if analysis_seg is None else analysis_seg
+    analysis_seg = (workflow.analysis_time if analysis_seg is None else
+                    analysis_seg)
 
     # make the directory that will contain the output files
     makedir(output_dir)
 
     # make a node for plotting the posterior as a corner plot
     node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
-                      out_dir=output_dir, universe="local",
-                      tags=tags).create_node()
+                          out_dir=output_dir, universe="local",
+                          tags=tags).create_node()
 
     # add command line options
     node.add_input_opt("--input-file", inference_file)
@@ -279,6 +283,7 @@ def make_inference_posterior_plot(
     workflow += node
 
     return node.output_files
+
 
 def make_inference_1d_posterior_plots(
                     workflow, inference_file, output_dir, parameters=None,
@@ -292,21 +297,22 @@ def make_inference_1d_posterior_plots(
                     tags=tags + [parameter])
     return files
 
-def make_inference_samples_plot(
-                    workflow, inference_file, output_dir, parameters=None,
-                    name="inference_samples", analysis_seg=None, tags=None):
+
+def make_inference_samples_plot(workflow, inference_file, output_dir,
+                                parameters=None, name="inference_samples",
+                                analysis_seg=None, tags=None):
     # default values
     tags = [] if tags is None else tags
-    analysis_seg = workflow.analysis_time \
-                       if analysis_seg is None else analysis_seg
+    analysis_seg = (workflow.analysis_time if analysis_seg is None else
+                    analysis_seg)
 
     # make the directory that will contain the output files
     makedir(output_dir)
 
     # make a node for plotting the posterior as a corner plot
     node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
-                      out_dir=output_dir, universe="local",
-                      tags=tags).create_node()
+                          out_dir=output_dir, universe="local",
+                          tags=tags).create_node()
 
     # add command line options
     node.add_input_opt("--input-file", inference_file)
@@ -320,7 +326,8 @@ def make_inference_samples_plot(
 
 
 def make_inference_acceptance_rate_plot(workflow, inference_file, output_dir,
-                    name="inference_rate", analysis_seg=None, tags=None):
+                                        name="inference_rate",
+                                        analysis_seg=None, tags=None):
     """ Sets up the acceptance rate plot in the workflow.
 
     Parameters
@@ -343,20 +350,20 @@ def make_inference_acceptance_rate_plot(workflow, inference_file, output_dir,
     Returns
     -------
     pycbc.workflow.FileList
-        A list of result and output files. 
+        A list of result and output files.
     """
 
     # default values
     tags = [] if tags is None else tags
-    analysis_seg = workflow.analysis_time \
-                       if analysis_seg is None else analysis_seg
+    analysis_seg = (workflow.analysis_time if analysis_seg is None else
+                    analysis_seg)
 
     # make the directory that will contain the output files
     makedir(output_dir)
 
     # make a node for plotting the acceptance rate
     node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
-                      out_dir=output_dir, tags=tags).create_node()
+                          out_dir=output_dir, tags=tags).create_node()
 
     # add command line options
     node.add_input_opt("--input-file", inference_file)
@@ -366,6 +373,7 @@ def make_inference_acceptance_rate_plot(workflow, inference_file, output_dir,
     workflow += node
 
     return node.output_files
+
 
 def make_inference_inj_plots(workflow, inference_files, output_dir,
                              parameters, name="inference_recovery",
@@ -394,13 +402,13 @@ def make_inference_inj_plots(workflow, inference_files, output_dir,
     Returns
     -------
     pycbc.workflow.FileList
-        A list of result and output files. 
+        A list of result and output files.
     """
 
     # default values
     tags = [] if tags is None else tags
-    analysis_seg = workflow.analysis_time \
-                       if analysis_seg is None else analysis_seg
+    analysis_seg = (workflow.analysis_time if analysis_seg is None else
+                    analysis_seg)
     output_files = FileList([])
 
     # make the directory that will contain the output files


### PR DESCRIPTION
This PR cleans up a large number of style problems in any and all python modules, using the `pep8` command line tool. The vast majority of issues fixed are to do with line length and whitespace. There are (should be?) no functional changes in any modules.