### PR TITLE
Added code owners based on copyright

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,3 +21,30 @@
 
 # tests
 /test/             @duncanmmacleod
+
+# -- modules ------------------------------------
+
+/gwin/                          @cdcapano
+/gwin/gelman_rubin.py           @cmbiwer
+/gwin/workflow.py               @cmbiwer
+
+/gwin/io/hdf.py                 @cmbiwer
+/gwin/io/txt.py                 @cmbiwer
+
+/gwin/sampler/                  @cmbiwer
+/gwin/sampler/mcmc.py           @vivienr
+
+# -- scripts ------------------------------------
+
+/bin/                           @cdcapano
+/bin/gwin                       @cmbiwer
+/bin/gwin_make_inj_workflow     @cmbiwer
+/bin/gwin_make_workflow         @cmbiwer
+/bin/gwin_plot_acceptance_rate  @cmbiwer
+/bin/gwin_plot_acf              @cmbiwer
+/bin/gwin_plot_acl              @cmbiwer
+/bin/gwin_plot_gelman_rubin     @cmbiwer
+/bin/gwin_plot_geweke           @cmbiwer
+/bin/gwin_plot_prior            @cmbiwer
+/bin/gwin_plot_samples          @cmbiwer
+/bin/gwin_table_summary         @cmbiwer


### PR DESCRIPTION
### Short version

This PR adds entries to codeowners for all of the python files in the repo based on the copyright headers in those files.

Fixes #7.

### Long version

@vivienr and I have experimented to the point where we understand the system (which includes our settings for the repo):

- if someone posts a PR that changes code owned by @duncanmmacleod, then I (@duncanmmacleod) will automatically be assigned to review that PR,
- GitHub provides a repo Setting named _**Require review from Code Owners**_, however that would **require** @duncanmmacleod to complete their review before the PR can be merged. This potentially presents a bottleneck if that individual is not available for any reason, so we have opted to **not use that option**,
- without that option @duncanmmacleod will still be automatically assigned to review, however a completed review is not required. Other individuals can be manually assigned, and as long as 1 review is completed, the PR can be merged by a privileged individual.

### Notes

@cdcapano is assigned by default to all files under `/bin/` and `/gwin/` (since he is the copyright owner of the majority of the files), so those few files that don't have a copyright statement are also owned by him.

@micamu is listed as a copyright owner of a few modules, but does not have the right 'status' to be assigned as a reviewer, so her name has not been included. I honestly don't know what github would do in that situation, but there's only one way to find out.

The complete list of named individuals is 

- @cdcapano 
- @cmbiwer
- @duncanmmacleod
- @vivienr