### PR TITLE
Added readthedocs configuration

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,4 @@
+python:
+  pip_install: true
+  extra_requirements:
+    - docs


### PR DESCRIPTION
This PR adds a trivial `readthedocs.yml` configuration file, allowing a working demonstration of auto-deploying gwin documentation to readthedocs.org.

This can easily be removed at a later date if we decide to go with github pages for docs hosting.