### PR TITLE
Modified sphinx configuration to run sphinx-apidoc as part of sphinx-build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,11 +14,11 @@ INCLUDES := $(shell ls _includes/*.py)
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help html clean apidoc Makefile
+.PHONY: help html clean Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-html: Makefile apidoc $(INCLUDES:.py=.rst)
+html: Makefile $(INCLUDES:.py=.rst)
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 clean: Makefile
@@ -27,9 +27,6 @@ clean: Makefile
 	@for EXRST in $(INCLUDES:.py=.rst); do \
 		$(RM) -f $$EXRST ; \
 	done
-
-apidoc: Makefile
-	@sphinx-apidoc --output-dir api --force --separate ../gwin
 
 # -- build includes from python files -----------------------------------------
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,7 +18,7 @@ help:
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-html: Makefile $(INCLUDES:.py=.rst)
+html: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 clean: Makefile
@@ -27,8 +27,3 @@ clean: Makefile
 	@for EXRST in $(INCLUDES:.py=.rst); do \
 		$(RM) -f $$EXRST ; \
 	done
-
-# -- build includes from python files -----------------------------------------
-
-_includes/%.rst: _includes/%.py
-	python _includes/$*.py > $@

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,10 @@
 
 import glob
 import os.path
+import subprocess
+import sys
+
+from sphinx.util import logging
 
 from gwin import __version__ as gwin_version
 
@@ -230,8 +234,25 @@ def setup_static_content(app):
             app.add_javascript(jsf.split(os.path.sep, 1)[1])
 
 
+# -- build _includes ----------------------------------------------------------
+
+def build_includes(app):
+    """Build extra include files from _includes dir
+    """
+    logger = logging.getLogger('includes')
+    curdir = os.path.abspath(os.path.dirname(__file__))
+    incdir = os.path.join(curdir, '_includes')
+    for pyf in glob.glob(os.path.join(curdir, '_includes', '*.py')):
+        rstfile = pyf.replace('.py', '.rst')
+        logger.info('generating {0} from {1}'.format(rstfile, pyf))
+        rst = subprocess.check_output([sys.executable, pyf])
+        with open(rstfile, 'w') as f:
+            f.write(rst)
+
+
 # -- setup --------------------------------------------------------------------
 
 def setup(app):
     setup_static_content(app)
     app.connect('builder-inited', run_apidoc)
+    app.connect('builder-inited', build_includes)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -200,9 +200,24 @@ autosummary_generate = True
 numpydoc_use_blockquotes = True
 
 
-# -- setup --------------------------------------------------------------------
+# -- run sphinx-apidoc automatically ------------------------------------------
+# this is required to have apidoc generated as part of readthedocs builds
+# see https://github.com/rtfd/readthedocs.org/issues/1139
 
-def setup(app):
+def run_apidoc(_):
+    """Call sphinx-apidoc
+    """
+    from sphinx.ext.apidoc import main as apidoc_main
+    curdir = os.path.abspath(os.path.dirname(__file__))
+    apidir = os.path.join(curdir, 'api')
+    module = os.path.join(curdir, os.path.pardir, 'gwin')
+    apidoc_main([module, '--separate', '--force', '--output-dir', apidir])
+
+
+# -- add static files----------------------------------------------------------
+
+def setup_static_content(app):
+    # configure stylesheets
     for sdir in html_static_path:
         # add stylesheets
         cssdir = os.path.join(sdir, 'css')
@@ -213,3 +228,10 @@ def setup(app):
         jsdir = os.path.join(sdir, 'js')
         for jsf in glob.glob(os.path.join(jsdir, '*.js')):
             app.add_javascript(jsf.split(os.path.sep, 1)[1])
+
+
+# -- setup --------------------------------------------------------------------
+
+def setup(app):
+    setup_static_content(app)
+    app.connect('builder-inited', run_apidoc)


### PR DESCRIPTION
This PR modifies the sphinx `conf.py` to trigger a `sphinx-apidoc` run during `sphinx-build`, as required to get the apidoc to build on readthedocs.org.

This also moves the `_includes` auto-generation into `conf.py` for the same reason.