### PR TITLE
Fixed CSS issue for docs on RTD

### DIFF
--- a/docs/_static/css/gwin.css
+++ b/docs/_static/css/gwin.css
@@ -7,6 +7,10 @@ pre {
 		font-size: 14px !important;
 }
 
+div[class^='highlight'] {
+		background-color: #272822;
+}
+
 code,
 .rst-content code {
 		border: none;


### PR DESCRIPTION
This PR fixes a CSS issue when displaying code blocks on gwin.readthedocs.io.