### PR TITLE
Added or corrected --version option in all scripts

### DIFF
--- a/bin/gwin
+++ b/bin/gwin
@@ -26,13 +26,12 @@ import shutil
 import numpy
 
 import pycbc
-import pycbc.version
 from pycbc import (calibration, distributions, transforms, fft, gate,
                    opt, psd, scheme, strain, weave)
 from pycbc.waveform import generator
 
 import gwin
-from gwin import (burn_in, option_utils)
+from gwin import (__version__, burn_in, option_utils)
 from gwin.io.hdf import InferenceFile
 from gwin.option_utils import validate_checkpoint_files
 
@@ -41,8 +40,7 @@ parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
                                  description=__doc__)
 
 # version option
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg,
+parser.add_argument("--version", action="version", version=__version__,
                     help="Prints version information.")
 
 # add data options

--- a/bin/gwin_extract_samples
+++ b/bin/gwin_extract_samples
@@ -35,12 +35,14 @@ import numpy
 
 import pycbc
 
-from gwin import option_utils
+from gwin import (__version__, option_utils)
 from gwin.io.hdf import InferenceFile
 from gwin.io.txt import InferenceTXTFile
 
 parser = argparse.ArgumentParser(description=__doc__)
 
+parser.add_argument('-V', '--version', action='version', version=__version__,
+                    help='show version number and exit')
 parser.add_argument("--output-file", type=str, required=True,
                     help="Output file to create.")
 parser.add_argument("--force", action="store_true", default=False,

--- a/bin/gwin_make_inj_workflow
+++ b/bin/gwin_make_inj_workflow
@@ -22,7 +22,6 @@ import argparse
 import logging
 import os
 import Pegasus.DAX3 as dax
-import pycbc.version
 import socket
 import sys
 from pycbc.results import layout
@@ -31,8 +30,9 @@ from pycbc.results import versioning
 from pycbc.workflow import configuration
 from pycbc.workflow import core
 from pycbc.workflow import jobsetup
-from gwin import workflow as gwin_workflow
 from pycbc.workflow import plotting
+
+from gwin import (__version__, workflow as gwin_workflow)
 
 # set command line parser
 parser = argparse.ArgumentParser(description=__doc__[1:])
@@ -40,7 +40,7 @@ parser = argparse.ArgumentParser(description=__doc__[1:])
 # version option
 parser.add_argument(
     "--version", action="version",
-    version=pycbc.version.git_verbose_msg, 
+    version=__version__,
     help="Prints version information.")
 
 # workflow options

--- a/bin/gwin_make_workflow
+++ b/bin/gwin_make_workflow
@@ -24,10 +24,8 @@ import logging
 import os
 import Pegasus.DAX3 as dax
 import pycbc.workflow as wf
-import gwin.workflow as inffu
 import pycbc.workflow.minifollowups as mini
 import pycbc.workflow.pegasus_workflow as wdax
-import pycbc.version
 import socket
 import sys
 from pycbc_glue import segments
@@ -36,6 +34,9 @@ from pycbc.results import layout
 from pycbc.types import MultiDetOptionAction
 from pycbc.types import MultiDetOptionAppendAction
 from pycbc.workflow import WorkflowConfigParser
+
+from gwin import (__version__, workflow as inffu)
+
 
 def to_file(path, ifo=None):
     """ Takes a str and returns a pycbc.workflow.pegasus_workflow.File
@@ -61,8 +62,7 @@ def symlink_path(f, path):
 parser = argparse.ArgumentParser(description=__doc__[1:])
 
 # version option
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg, 
+parser.add_argument("--version", action="version", version=__version__,
                     help="Prints version information.")
 
 # workflow options

--- a/bin/gwin_plot_acceptance_rate
+++ b/bin/gwin_plot_acceptance_rate
@@ -26,12 +26,15 @@ from matplotlib import pyplot as plt
 
 from pycbc import results
 
+from gwin import __version__
 from gwin.io.hdf import InferenceFile
 
 # command line usage
 parser = argparse.ArgumentParser(
             usage="pycbc_inference_plot_acceptance_rate [--options]",
             description="Plots histogram of the fractions of steps accepted by walkers.")
+parser.add_argument('--version', action='version', version=__version__,
+                    help='show version number and exit')
 
 # add data options
 parser.add_argument("--input-file", type=str, required=True,

--- a/bin/gwin_plot_acf
+++ b/bin/gwin_plot_acf
@@ -27,7 +27,7 @@ from matplotlib import pyplot as plt
 import pycbc
 from pycbc import results
 
-from gwin import option_utils
+from gwin import (__version__, option_utils)
 
 # command line usage
 parser = argparse.ArgumentParser(
@@ -36,6 +36,8 @@ parser = argparse.ArgumentParser(
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
     help="Print logging info.")
+parser.add_argument('--version', action='version', version=__version__,
+                    help='show version number and exit')
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")

--- a/bin/gwin_plot_acl
+++ b/bin/gwin_plot_acl
@@ -30,7 +30,7 @@ import pycbc
 from pycbc import results
 from pycbc.filter import autocorrelation
 
-from gwin import option_utils
+from gwin import (__version__, option_utils)
 
 # command line usage
 parser = argparse.ArgumentParser(
@@ -39,6 +39,8 @@ parser = argparse.ArgumentParser(
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
     help="Print logging info.")
+parser.add_argument('--version', action='version', version=__version__,
+                    help='show version number and exit')
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")

--- a/bin/gwin_plot_gelman_rubin
+++ b/bin/gwin_plot_gelman_rubin
@@ -20,10 +20,9 @@
 import argparse
 import logging
 from pycbc import results
-from gwin import gelman_rubin
-from gwin import option_utils
 import matplotlib.pyplot as plt
 import sys
+from gwin import (__version__, gelman_rubin, option_utils)
 
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
@@ -32,6 +31,8 @@ parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
                     help="Print logging info.")
+parser.add_argument('--version', action='version', version=__version__,
+                    help='show version number and exit')
 
 # output options
 parser.add_argument("--output-file", type=str, required=True,

--- a/bin/gwin_plot_geweke
+++ b/bin/gwin_plot_geweke
@@ -24,9 +24,9 @@ import matplotlib as mpl; mpl.use("Agg")
 import matplotlib.pyplot as plt
 import pycbc
 from pycbc import results
-from gwin import geweke
-from gwin import option_utils
 import sys
+
+from gwin import (__version__, geweke, option_utils)
 
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
@@ -35,6 +35,8 @@ parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
     help="Print logging info.")
+parser.add_argument('--version', action='version', version=__version__,
+                    help='show version number and exit')
 
 # output options
 parser.add_argument("--output-file", type=str, required=True,

--- a/bin/gwin_plot_inj_intervals
+++ b/bin/gwin_plot_inj_intervals
@@ -18,11 +18,13 @@ from matplotlib import pyplot as plt
 import pycbc
 from pycbc.results import save_fig_with_metadata
 
-from gwin import option_utils
+from gwin import (__version__, option_utils)
 
 # parse command line
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
                                  description=__doc__)
+parser.add_argument('--version', action='version', version=__version__,
+                    help='show version number and exit')
 parser.add_argument("--output-file", required=True, type=str,
                     help="Path to save output plot.")
 parser.add_argument("--verbose", action="store_true",

--- a/bin/gwin_plot_inj_recovery
+++ b/bin/gwin_plot_inj_recovery
@@ -14,13 +14,12 @@ import pycbc.version
 from matplotlib import cm
 from pycbc import inject
 from pycbc import transforms
-from gwin import option_utils
+from gwin import (__version__, option_utils)
 
 # parse command line
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
                                  description=__doc__)
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg,
+parser.add_argument("--version", action="version", version=__version__,
                     help="Prints version information.")
 parser.add_argument("--output-file", required=True, type=str,
                     help="Path to save output plot.")

--- a/bin/gwin_plot_movie
+++ b/bin/gwin_plot_movie
@@ -41,7 +41,7 @@ from matplotlib import pyplot
 import pycbc.results
 from pycbc import transforms
 
-from gwin import option_utils
+from gwin import (__version__, option_utils)
 from gwin.results.scatter_histograms import (create_multidim_plot,
                                              get_scale_fac)
 
@@ -93,6 +93,8 @@ def integer_logspace(start, end, num):
 
 parser = argparse.ArgumentParser()
 
+parser.add_argument("--version", action="version", version=__version__,
+                    help="show version number and exit")
 parser.add_argument("--input-file", type=str, required=True,
                     help="Results file path.")
 parser.add_argument("--start-sample", type=int, default=1,

--- a/bin/gwin_plot_posterior
+++ b/bin/gwin_plot_posterior
@@ -39,14 +39,13 @@ import pycbc.version
 from pycbc.results import metadata
 from pycbc.results.scatter_histograms import create_multidim_plot
 
-from gwin import option_utils
+from gwin import (__version__, option_utils)
 
 use('agg')
 
 # add options to command line
 parser = argparse.ArgumentParser()
-parser.add_argument("--version", action="version",
-                    version=pycbc.version.git_verbose_msg,
+parser.add_argument("--version", action="version", version=__version__,
                     help="Prints version information.")
 parser.add_argument("--output-file", type=str, required=True,
                     help="Output plot path.")

--- a/bin/gwin_plot_prior
+++ b/bin/gwin_plot_prior
@@ -33,6 +33,8 @@ import corner
 from pycbc import (distributions, results)
 from pycbc.workflow import WorkflowConfigParser
 
+from gwin import __version__
+
 
 def cartesian(arrays):
     """ Returns a cartesian product from a list of iterables.
@@ -60,6 +62,8 @@ parser.add_argument("--output-file", type=str, required=True,
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
     help="")
+parser.add_argument("--version", action="version", version=__version__,
+                    help="show version number and exit")
 
 # parse the command line
 opts = parser.parse_args()

--- a/bin/gwin_plot_samples
+++ b/bin/gwin_plot_samples
@@ -29,7 +29,7 @@ from matplotlib import pyplot as plt
 import pycbc
 from pycbc import (results, transforms)
 
-from gwin import option_utils
+from gwin import (__version__, option_utils)
 
 # command line usage
 parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
@@ -38,6 +38,8 @@ parser = argparse.ArgumentParser(usage=__file__ + " [--options]",
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
                     help="Print logging info.")
+parser.add_argument("--version", action="version", version=__version__,
+                    help="show version number and exit")
 
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,

--- a/bin/gwin_table_summary
+++ b/bin/gwin_table_summary
@@ -24,7 +24,7 @@ import numpy
 
 from pycbc import results
 
-from gwin import option_utils
+from gwin import (option_utils, __version__)
 
 # command line usage
 parser = argparse.ArgumentParser(
@@ -32,6 +32,8 @@ parser = argparse.ArgumentParser(
 # verbose option
 parser.add_argument("--verbose", action="store_true", default=False,
     help="Print logging info.")
+parser.add_argument("--version", action="version", version=__version__,
+                    help="show version number and exit")
 # output plot options
 parser.add_argument("--output-file", type=str, required=True,
     help="Path to output plot.")


### PR DESCRIPTION
This PR adds or corrects the `--version` option for all command-line scripts to print `gwin.__version__`.

Fixes #29.