### PR TITLE
Loosen Code Climate checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,8 +13,6 @@ checks:
   method-lines:
     config:
       threshold: 100
-  method-complexity:
-    enabled:  false
 
 plugins:
   duplication:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,10 +3,16 @@ version: "2"
 checks:
   argument-count:
     config:
-      threshold: 5
+      threshold: 10
   file-lines:
     config:
       threshold: 500
+  method-count:
+    config:
+      threshold: 50
+  method-lines:
+    config:
+      threshold: 100
 
 plugins:
   duplication:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,6 +13,8 @@ checks:
   method-lines:
     config:
       threshold: 100
+  method-complexity:
+    enabled:  false
 
 plugins:
   duplication:


### PR DESCRIPTION
I think the checks in Code Climate are currently too draconian. This changes the following (I think anyway... not entirely should I got the right commands):
 * increases the number of allowed function arguments from 5 to 10.
 * increases the number of methods allowed for a class from 20 (the default) to 50.
 * increases the number of lines allowed in a function from 25 (the default) to 100.
 * turns off the cognitive complexity test.

I want to turn off the cognitive complexity test because it's not really well defined what it's doing. For example, in #17, Code Climate complained that [this](https://github.com/cdcapano/gwin/blob/3c872c46b68b04622073e2b1c3177ab8fa27d59d/gwin/likelihood.py#L341-L358) function had a cognitive complexity of 6, which was above the threshold of 5. I don't really know what that means, and I personally didn't find that function to be very hard to understand (granted, I'm biased, since I wrote it). Really, this is something that is the reviewers job to check.

For similar reasons I'm also tempted to turn off the cyclomatic complexity test, but can see how that might be able to provide feedback that a reviewer might not immediately catch.