### PR TITLE
WIP: Add sub dax

### DIFF
--- a/bin/gwin_make_workflow
+++ b/bin/gwin_make_workflow
@@ -76,6 +76,11 @@ parser.add_argument("--output-map", required=True,
                     help="Path to output map file.")
 parser.add_argument("--output-file", required=True,
                     help="Path to DAX file.")
+parser.add_argument("--submit-dax", action="store_true", default=False,
+                    help="If specified then the dax will be automatically "
+                         "submitted.")
+parser.add_argument("--accounting-group", required=False, default=None,
+                    help="cluster accounting group tag.")
 
 # input workflow file options
 parser.add_argument("--bank-file", default=None,
@@ -115,6 +120,11 @@ opts = parser.parse_args()
 # log to terminal until we know where the path to log output file
 log_format = "%(asctime)s:%(levelname)s : %(message)s"
 logging.basicConfig(format=log_format, level=logging.INFO)
+
+# if dax submission then check an accounting group is parsed
+if opts.submit_dax:
+    assert(opts.accounting_group != None,
+           "Please specify --accounting-group")
 
 # create workflow and sub-workflows
 container = wf.Workflow(opts, opts.workflow_name)
@@ -412,6 +422,21 @@ base = rdir["priors/configuration"]
 wf.makedir(base)
 prior_ini = workflow.save_config("priors.ini", base, cp)
 layout.single_layout(base, prior_ini)
+
+# submit dax if specified
+if opts.submit_dax:
+    logging.info("preparing to submit dax")
+    dax_cmd = "pycbc_submit_dax"
+    dax_opt = "--dax {}.dax ".format(opts.workflow_name) + \
+              "--accounting-group {} ".format(accounting_group) + \
+              "--enable-shared-filesystem"
+
+    import subprocess
+    try:
+        subprocess.call([dax_cmd, dax_opt])
+        logging.info("dax submission successful")
+    except:
+        logging.info("dax submission failed")
 
 # close the log and flush to the html file
 logging.shutdown()

--- a/bin/gwin_make_workflow
+++ b/bin/gwin_make_workflow
@@ -33,7 +33,7 @@ from pycbc import results
 from pycbc.results import layout
 from pycbc.types import MultiDetOptionAction
 from pycbc.types import MultiDetOptionAppendAction
-from pycbc.workflow import WorkflowConfigParser
+from pycbc.workflow import WorkflowConfigParser, make_external_call
 
 from gwin import (__version__, workflow as inffu)
 
@@ -425,20 +425,23 @@ layout.single_layout(base, prior_ini)
 # submit dax if specified
 if opts.submit_dax:
     logging.info("preparing to submit dax")
-    dax_cmd = "pycbc_submit_dax "
-    dax_opt = "--dax {}.dax ".format(opts.workflow_name) + \
-              "--accounting-group {} ".format(opts.accounting_group) + \
-              "--enable-shared-filesystem " + \
-              "--no-create-proxy"
+    dax_call = ["pycbc_submit_dax " + \
+                "--dax {}.dax ".format(opts.workflow_name) + \
+                "--accounting-group {} ".format(opts.accounting_group) + \
+                "--enable-shared-filesystem --no-create-proxy"]
+    #TODO: should do some error checking here
+    p=make_external_call(dax_call, shell=True, fail_on_error=False)
 
-    #import subprocess
-    import os
-    try:
-        #subprocess.call([dax_cmd, dax_opt])
-        os.system(dax_cmd +  dax_opt)
-        logging.info("dax submission successful")
-    except:
-        logging.info("dax submission failed")
+    #try:
+    #    logging.info("dax submission successful")
+    #     dax_call = ["pycbc_submit_dax " + \
+    #                 "--dax {}.dax ".format(opts.workflow_name) + \
+    #                 "--accounting-group {} ".format(opts.accounting_group) + \
+    #                 "--enable-shared-filesystem --no-create-proxy"]
+    #     p=make_external_call(dax_call, shell=True, fail_on_error=False)
+    #     logging.info(p)
+    #except:
+    #    logging.info("dax submission failed")
 
 # close the log and flush to the html file
 logging.shutdown()

--- a/bin/gwin_make_workflow
+++ b/bin/gwin_make_workflow
@@ -123,8 +123,7 @@ logging.basicConfig(format=log_format, level=logging.INFO)
 
 # if dax submission then check an accounting group is parsed
 if opts.submit_dax:
-    assert(opts.accounting_group != None,
-           "Please specify --accounting-group")
+    assert opts.accounting_group != None, "Please specify --accounting-group"
 
 # create workflow and sub-workflows
 container = wf.Workflow(opts, opts.workflow_name)
@@ -426,14 +425,16 @@ layout.single_layout(base, prior_ini)
 # submit dax if specified
 if opts.submit_dax:
     logging.info("preparing to submit dax")
-    dax_cmd = "pycbc_submit_dax"
+    dax_cmd = "pycbc_submit_dax "
     dax_opt = "--dax {}.dax ".format(opts.workflow_name) + \
-              "--accounting-group {} ".format(accounting_group) + \
+              "--accounting-group {} ".format(opts.accounting_group) + \
               "--enable-shared-filesystem"
 
-    import subprocess
+    #import subprocess
+    import os
     try:
-        subprocess.call([dax_cmd, dax_opt])
+        #subprocess.call([dax_cmd, dax_opt])
+        os.system(dax_cmd +  dax_opt)
         logging.info("dax submission successful")
     except:
         logging.info("dax submission failed")

--- a/bin/gwin_make_workflow
+++ b/bin/gwin_make_workflow
@@ -428,7 +428,8 @@ if opts.submit_dax:
     dax_cmd = "pycbc_submit_dax "
     dax_opt = "--dax {}.dax ".format(opts.workflow_name) + \
               "--accounting-group {} ".format(opts.accounting_group) + \
-              "--enable-shared-filesystem"
+              "--enable-shared-filesystem " + \
+              "--no-create-proxy"
 
     #import subprocess
     import os


### PR DESCRIPTION
Some of us think it would be good to have the option to both make a gwin workflow *and* submit the dax to a cluster using a single command. This RP attempts to do this however, it is not entirely suitable at the moment I don't think.

I would like some feedback from @spxiwh.

I found that the only way I could get this to work was if I used the `shell=True` option of `make_external_call`.

Also I added the `fail_on_error=False` flag to `make_external_call` because even though when I ran `gwin_make_workflow` with the new `--submit-dax` flag the code ran to completion, submitted the dax successfully but also `make_external_call` returned an error code for some reason, even though the dax was actually submitted successfully.

Am I missing some tricks in order to get this to work nicer? Because I would like to add some checks or `try/except` when I try to submit the dax to try and catch an issues.

Perhaps we don't want to go down this route but I'd like to start the discussion on it here.

