### PR TITLE
Update plotting

### DIFF
--- a/bin/gwin_plot_movie
+++ b/bin/gwin_plot_movie
@@ -41,7 +41,7 @@ from matplotlib import pyplot
 import pycbc.results
 from pycbc import transforms
 
-from gwin import (__version__, option_utils)
+from gwin import (__version__, option_utils, io)
 from gwin.results.scatter_histograms import (create_multidim_plot,
                                              get_scale_fac)
 
@@ -91,12 +91,12 @@ def integer_logspace(start, end, num):
     out[start_idx:len(x)+start_idx] = x
     return out
 
-parser = argparse.ArgumentParser()
-
+# we won't add thinning arguments nor iteration, since this is determined by
+# the frame number/step options
+skip_args = ['thin-start', 'thin-interval', 'thin-end', 'iteration']
+parser = io.ResultsArgumentParser(skip_args=skip_args)
 parser.add_argument("--version", action="version", version=__version__,
                     help="show version number and exit")
-parser.add_argument("--input-file", type=str, required=True,
-                    help="Results file path.")
 parser.add_argument("--start-sample", type=int, default=1,
                     help="Start sample for the first frame. Note: sample "
                          "counting starts from 1. Default is 1.")
@@ -117,10 +117,6 @@ parser.add_argument("--log-steps", action="store_true", default=False,
 parser.add_argument("--output-prefix", type=str, required=True,
                     help="Output path and prefix for the frame files "
                          "(without extension).")
-parser.add_argument("--parameters", type=str, nargs="+",
-                    metavar="PARAM[:LABEL]",
-                    help="Name of parameters to plot in same format "
-                         "as for pycbc_inference_plot_posterior.")
 parser.add_argument('--verbose', action='store_true')
 parser.add_argument('--dpi', type=int, default=200,
                     help='Set the dpi for each frame; default is 200')
@@ -144,10 +140,12 @@ option_utils.add_density_option_group(parser)
 opts = parser.parse_args()
 pycbc.init_logging(opts.verbose)
 
+if len(opts.input_file) > 1:
+    raise ValueError("this program can only plot one file at a time")
+
 # Get data
 logging.info('Loading parameters')
-fp, parameters, labels, _ = option_utils.results_from_cli(opts,
-                            load_samples=False)
+fp, parameters, labels, _ = io.results_from_cli(opts, load_samples=False)
 
 if opts.end_sample is None:
     opts.end_sample = fp.niterations
@@ -190,31 +188,29 @@ else:
     raise ValueError("At least one of frame-number or frame-step must be "
                      "provided.")
 
-# get samples from InferenceFile
+# get the samples
 file_parameters, trans = transforms.get_common_cbc_transforms(
                                          parameters, fp.variable_params)
-samples = fp.read_samples(file_parameters, thin_start=thin_start,
-                          thin_interval=thinint, thin_end=thin_end,
-                          iteration=itermask, flatten=False)
+samples = fp.samples_from_cli(opts, file_parameters, thin_start=thin_start,
+                              thin_interval=thinint, thin_end=thin_end,
+                              iteration=itermask, flatten=False)
 samples = transforms.apply_transforms(samples, trans)
 if samples.ndim > 2:
-    # multi-tempered samplers will return a 3 dims, so flatten
+    # multi-tempered samplers will return 3 dims, so flatten
     _, ii, jj = samples.shape
     samples = samples.reshape((ii, jj))
 
 # Get z-values
 if opts.z_arg is not None:
-    logging.info("Getting model stats")
-    z_arg, zlbl = option_utils.parse_parameters_opt([opts.z_arg])
-    z_arg = z_arg[0]
-    zlbl = zlbl[z_arg]
-    model_stats = fp.read_model_stats(thin_start=thin_start,
-        thin_end=thin_end, thin_interval=thinint, iteration=itermask,
-        flatten=False)
-    if model_stats.ndim > 2:
-        _, ii, jj = model_stats.shape
-        model_stats = model_stats.reshape((ii, jj))
-    zvals = model_stats[z_arg]
+    logging.info("Getting samples for colorbar")
+    zsamples = fp.samples_from_cli(opts, opts.z_arg, thin_start=thin_start,
+                                   thin_interval=thinint, thin_end=thin_end,
+                                   iteration=itermask, flatten=False)
+    zlbl = opts.z_arg_labels[opts.z_arg]
+    if zsamples.ndim > 2:
+        _, ii, jj = zsamples.shape
+        zsamples = zsamples.reshape((ii, jj))
+    zvals = zsamples[opts.z_arg]
     show_colorbar = True
     # Set common min and max for colorbar in all plots
     if opts.vmin is None:
@@ -236,10 +232,16 @@ fp.close()
 # get injection values if desired
 expected_parameters = {}
 if opts.plot_injection_parameters:
-    injections = option_utils.injections_from_cli(opts)
+    injections = io.injections_from_cli(opts)
     for p in parameters:
         # check that all of the injections are the same
-        unique_vals = numpy.unique(injections[p])
+        try:
+            vals = injections[p]
+        except NameError:
+            # injection doesn't have this parameter, skip
+            logging.warn("Could not find injection parameter {}".format(p))
+            continue
+        unique_vals = numpy.unique(vals)
         if unique_vals.size != 1:
             raise ValueError("More than one injection found! To use "
                 "plot-injection-parameters, there must be a single unique "
@@ -247,6 +249,7 @@ if opts.plot_injection_parameters:
                 "option to specify an expected parameter instead.")
         # passed: use the value for the expected
         expected_parameters[p] = unique_vals[0]
+
 # get expected parameter values from command line
 expected_parameters.update(option_utils.expected_parameters_from_cli(opts))
 expected_parameters_color = opts.expected_parameters_color

--- a/bin/gwin_plot_posterior
+++ b/bin/gwin_plot_posterior
@@ -192,9 +192,6 @@ if len(opts.input_file) > 1:
 # set DPI
 fig.set_dpi(200)
 
-# set tight layout
-fig.set_tight_layout(True)
-
 # save
 metadata.save_fig_with_metadata(
                  fig, opts.output_file, {},

--- a/bin/gwin_plot_posterior
+++ b/bin/gwin_plot_posterior
@@ -118,7 +118,13 @@ if opts.plot_injection_parameters:
     injections = io.injections_from_cli(opts)
     for p in parameters:
         # check that all of the injections are the same
-        unique_vals = numpy.unique(injections[p])
+        try:
+            vals = injections[p]
+        except NameError:
+            # injection doesn't have this parameter, skip
+            logging.warn("Could not find injection parameter {}".format(p))
+            continue
+        unique_vals = numpy.unique(vals)
         if unique_vals.size != 1:
             raise ValueError("More than one injection found! To use "
                 "plot-injection-parameters, there must be a single unique "

--- a/bin/gwin_plot_posterior
+++ b/bin/gwin_plot_posterior
@@ -37,35 +37,27 @@ from matplotlib import (patches, use)
 import pycbc
 import pycbc.version
 from pycbc.results import metadata
-from pycbc.results.scatter_histograms import create_multidim_plot
 
-from gwin import (__version__, option_utils)
+from gwin import (__version__, option_utils, io)
+from gwin.results.scatter_histograms import create_multidim_plot
 
 use('agg')
 
 # add options to command line
-parser = argparse.ArgumentParser()
+parser = io.ResultsArgumentParser()
+# program-specific
 parser.add_argument("--version", action="version", version=__version__,
                     help="Prints version information.")
 parser.add_argument("--output-file", type=str, required=True,
                     help="Output plot path.")
 parser.add_argument("--verbose", action="store_true", default=False,
                     help="Be verbose")
-parser.add_argument("--input-file-labels", nargs="+", default=None,
-                    help="Labels to add to plot if using more than one"
-                         "input file.")
-
 # add options for what plots to create
 option_utils.add_plot_posterior_option_group(parser)
-
 # scatter configuration
 option_utils.add_scatter_option_group(parser)
-
 # density configuration
 option_utils.add_density_option_group(parser)
-
-# add standard option utils
-option_utils.add_inference_results_option_group(parser)
 
 # parse command line
 opts = parser.parse_args()
@@ -73,52 +65,34 @@ opts = parser.parse_args()
 # set logging
 pycbc.init_logging(opts.verbose)
 
-# get parameters
-logging.info("Loading parameters")
-fp, parameters, labels, samples = option_utils.results_from_cli(opts)
+# load the samples
+fps, parameters, labels, samples = io.results_from_cli(opts)
 
 # typecast to list so the input files can be iterated over
-fp = fp if isinstance(fp, list) else [fp]
-parameters = parameters if isinstance(parameters[0], list) else [parameters]
-labels = labels if isinstance(labels[0], list) else [labels]
+fps = fps if isinstance(fps, list) else [fps]
 samples = samples if isinstance(samples, list) else [samples]
 
-# get likelihood statistic values
+# if a z-arg is specified, load samples for it
 if opts.z_arg is not None:
-    logging.info("Getting model stats")
-
-    z_arg, f_zlbl = option_utils.parse_parameters_opt([opts.z_arg])
-    z_arg = z_arg[0]
-    f_zlbl = f_zlbl[z_arg]
-
-    # lists to hold z-axis values and labels for each input file
+    logging.info("Getting samples for colorbar")
+    zlbl = opts.z_arg_labels[opts.z_arg]
     zvals = []
-    zlbl = []
-
-    # loop over each input file and append z-axis values and labels to lists
-    for f in fp:
-        model_stats = f.read_model_stats(
-            thin_start=opts.thin_start, thin_end=opts.thin_end,
-            thin_interval=opts.thin_interval, iteration=opts.iteration)
-        zvals.append(model_stats[z_arg])
-        zlbl.append(f_zlbl)
-        f.close()
-
-# else there are no z-axis values
+    for fp in fps:
+        zsamples = fp.samples_from_cli(opts, parameters=opts.z_arg)
+        zvals.append(zsamples[opts.z_arg])
 else:
     zvals = None
     zlbl = None
-    for f in fp:
-        f.close()
 
-# determine if colorbar should be shown
-show_colorbar = True if opts.z_arg else False
+# closet the files, we don't need them anymore
+for fp in fps:
+    fp.close()
 
 # if no plotting options selected, then the default options are based
 # on the number of parameters
 plot_options = [opts.plot_marginal, opts.plot_scatter, opts.plot_density]
 if not numpy.any(plot_options):
-    if len(parameters[0]) == 1:
+    if len(parameters) == 1:
         opts.plot_marginal = True
     else:
         opts.plot_scatter = True
@@ -132,7 +106,7 @@ if not numpy.any(plot_options):
 mins, maxs = option_utils.plot_ranges_from_cli(opts)
 
 # add any missing parameters
-for p in parameters[0]:
+for p in parameters:
     if p not in mins:
         mins[p] = numpy.array([s[p].min() for s in samples]).min()
     if p not in maxs:
@@ -141,8 +115,8 @@ for p in parameters[0]:
 # get injection values if desired
 expected_parameters = {}
 if opts.plot_injection_parameters:
-    injections = option_utils.injections_from_cli(opts)
-    for p in parameters[0]:
+    injections = io.injections_from_cli(opts)
+    for p in parameters:
         # check that all of the injections are the same
         unique_vals = numpy.unique(injections[p])
         if unique_vals.size != 1:
@@ -162,7 +136,7 @@ colors = itertools.cycle(["black"] + ["C{}".format(i) for i in range(10)])
 # plot each input file
 logging.info("Plotting")
 hist_colors = []
-for i, (p, l, s) in enumerate(zip(parameters, labels, samples)):
+for (i, s) in enumerate(samples):
 
     # on first iteration create figure otherwise update old figure
     if i == 0:
@@ -185,13 +159,13 @@ for i, (p, l, s) in enumerate(zip(parameters, labels, samples)):
 
     # plot
     fig, axis_dict = create_multidim_plot(
-                    p, s, labels=l, fig=fig, axis_dict=axis_dict,
+                    parameters, s, labels=labels, fig=fig, axis_dict=axis_dict,
                     plot_marginal=opts.plot_marginal,
                     marginal_percentiles=opts.marginal_percentiles,
                     plot_scatter=opts.plot_scatter,
                     zvals=zvals[i] if zvals is not None else None,
-                    show_colorbar=show_colorbar,
-                    cbar_label=zlbl[i] if zlbl is not None else None,
+                    show_colorbar=opts.z_arg is not None,
+                    cbar_label=zlbl,
                     vmin=opts.vmin, vmax=opts.vmax,
                     scatter_cmap=opts.scatter_cmap,
                     plot_density=opts.plot_density,
@@ -208,7 +182,7 @@ for i, (p, l, s) in enumerate(zip(parameters, labels, samples)):
                     expected_parameters_color=opts.expected_parameters_color)
 
 # add legend to upper right for input files
-if opts.input_file_labels:
+if len(opts.input_file) > 1:
     handles = []
     for color, label in zip(hist_colors, opts.input_file_labels):
         handles.append(patches.Patch(color=color, label=label))

--- a/gwin/io/__init__.py
+++ b/gwin/io/__init__.py
@@ -631,9 +631,4 @@ def injections_from_cli(opts):
             injections = these_injs
         else:
             injections = injections.append(these_injs)
-    # check if need extra parameters than parameters stored in injection file
-    _, ts = _transforms.get_common_cbc_transforms(opts.parameters,
-                                                  injections.fieldnames)
-    # add parameters not included in injection file
-    injections = _transforms.apply_transforms(injections, ts)
     return injections

--- a/gwin/io/__init__.py
+++ b/gwin/io/__init__.py
@@ -26,6 +26,7 @@ import shutil
 import logging
 import h5py as _h5py
 from pycbc.io.record import FieldArray, _numpy_function_lib
+from pycbc import waveform as _waveform
 
 from .emcee import EmceeFile
 from .txt import InferenceTXTFile
@@ -70,223 +71,6 @@ def loadfile(path, mode=None, filetype=None, **kwargs):
             raise IOError("The file appears not to exist. In this case, "
                           "filetype must be provided.")
     return filetypes[filetype](path, mode=mode, **kwargs)
-
-
-#
-# =============================================================================
-#
-#                         CLI Utilities
-#
-# =============================================================================
-#
-
-class PrintFileParams(argparse.Action):
-    """Argparse action that will load input files and print possible parameters
-    to screen. Once this is done, the program is forced to exit immediately.
-
-    The behvior is similar to --help, except that the input-file is read.
-    """
-    def __init__(self, nargs=0, **kwargs):
-        if nargs != 0:
-            raise ValueError("nargs for this action must be 0")
-        super(PrintParams, self).__init__(nargs=nargs, **kwargs)
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        # get the input file(s)
-        input_files = namespace.input_file
-        if input_files is None:
-            raise ValueError("must provide at least one input-file")
-        parameters = []
-        filesbytype = {}
-        fileparsers = {}
-        for fn in input_files:
-            fp = loadfile(fn, 'r')
-            parameters.append(set(fp[fp.samples_group].keys()))
-            try:
-                filesbytype[fp.name].append(fn)
-            except KeyError:
-                filesbytype[fp.name] = [fn]
-                # get any extra options
-                fileparsers[fp.name] = fp.extra_args_parser(add_help=False)
-            fp.close()
-        # print out the extra arguments that may be used
-        outstr = "Additional command-line options that may be provided:\n"
-        for ftype, fparser in fileparsers.items():
-            fnames = ', '.join(filesbytype[ftype])
-            if fparser is None:
-                outstr = "\nFile(s) {} use no additional options.".format(
-                    fnames)
-            else:
-                outstr = "\nThe following are used by file(s) {}:".format(
-                    fnames)
-                fparser.print_help()
-        # now print information about the parameters
-        # take the intersection of all parameters
-        parameters = set.intersection(*parameters)
-        outstr = ("With the given input file(s), the following parameters are "
-                  "available:\n{}\n".format(' '.join(sorted(parameters))))
-        outstr += ("\nThe following pycbc functions may be used on these "
-                   "parameters (see http://pycbc.org/pycbc/latest/html for "
-                   "more details):\n{}\n".format(' '.join(sorted(
-                   FieldArray.functionlib.fget(FieldArray).keys()))))
-        outstr += ("\nThe following numpy functions may be used on these "
-                   "parameters:\n{}\n".format(
-                   ' '.join(sorted(_numpy_function_lib.keys()))))
-        print(outstr, file=sys.stdout)
-        # exit the program
-        parser.exit(0)
-
-
-def add_results_option_group(parser):
-    """Adds the options used to call gwin.io.results_from_cli function
-    to an argument parser.
-    
-    These are options releated to loading the results from a run of
-    gwin, for purposes of plotting and/or creating tables.
-
-    Parameters
-    ----------
-    parser : object
-        ArgumentParser instance.
-    """
-
-    results_reading_group = parser.add_argument_group(
-        "Arguments for loading results. Additional, file-specific arguments "
-        "may also be provided, depending on what input-files are given. See "
-        "print-all-opts for details.")
-
-    # required options
-    results_reading_group.add_argument(
-        "--input-file", type=str, required=True, nargs="+",
-        help="Path to input HDF file(s).")
-    results_reading_group.add_argument(
-        "--parameters", type=str, nargs="+", metavar="PARAM[:LABEL]",
-        help="Name of parameters to load. If none provided will load all of "
-             "the model params in the input-file. If provided, the "
-             "parameters can be any of the model params or posteriors in "
-             "the input file, derived parameters from them, or any function "
-             "of them. Syntax for functions is python; any math functions in "
-             "the numpy libary may be used. Can optionally also specify a "
-             "label for each parameter. If no label is provided, will try to "
-             "retrieve a label from the input-file. If no label can be found "
-             "in the input-file, will try to get a label from "
-             "pycbc.waveform.parameters. If no label can be found in either "
-             "place, will just use the parameter. To see all possible "
-             "parameters that may be used, as well as avaiable functions, run "
-             "--print-all-opts, along with one or more input files.")
-    # optionals
-    results_reading_group.add_argument(
-        "--thin-start", type=int, default=None,
-        help="Sample number to start collecting samples to plot. If none "
-             "provided, will use the input file's `thin_start` attribute.")
-    results_reading_group.add_argument(
-        "--thin-interval", type=int, default=None,
-        help="Interval to use for thinning samples. If none provided, will "
-             "use the input file's `thin_interval` attribute.")
-    results_reading_group.add_argument(
-        "--thin-end", type=int, default=None,
-        help="Sample number to stop collecting samples to plot. If none "
-             "provided, will use the input file's `thin_end` attribute.")
-    # advanced help
-    results.reading_group.add_argument(
-        "-H", "--print-all-opts", action=PrintFileParams,
-        help="Based on the provided input-file(s), print all available "
-             "parameters that may be retrieved and all possible functions on "
-             "those parameters. Also print available additional arguments "
-             "that may be passed. This option is like an "
-             "advanced --help: if run, the program will just print the "
-             "information to screen, then exit."
-    return results_reading_group
-
-
-def results_from_cli(opts, extra_opts=None, load_samples=True, **kwargs):
-    """
-    Loads an inference result file along with any labels associated with it
-    from the command line options.
-
-    Parameters
-    ----------
-    opts : ArgumentParser options
-        The options from the command line.
-    load_samples : bool, optional
-        Load the samples from the file.
-
-    **kwargs :
-        All other keyword arguments are passed to the InferenceFile's
-        read_samples function.
-
-    Returns
-    -------
-    fp_all : pycbc.io.InferenceFile
-        The result file as an InferenceFile. If more than one input file,
-        then it returns a list.
-    parameters_all : list
-        List of the parameters to use, parsed from the parameters option.
-        If more than one input file, then it returns a list.
-    labels_all : list
-        List of labels to associate with the parameters. If more than one
-        input file, then it returns a list.
-    samples_all : {None, FieldArray}
-        If load_samples, the samples as a FieldArray; otherwise, None.
-        If more than one input file, then it returns a list.
-    """
-
-    # lists for files and samples from all input files
-    fp_all = []
-    parameters_all = []
-    labels_all = {}
-    samples_all = []
-
-    input_files = opts.input_file
-    if isinstance(input_files, str):
-        input_files = [input_files]
-
-    # loop over all input files
-    for input_file in input_files:
-        logging.info("Reading input file %s", input_file)
-
-        # read input file
-        fp = loadfile(input_file, "r")
-
-        # get parameters and a dict of labels for each parameter
-        parameters, ldict = fp.parameters_from_cli(opts)
-
-        # load the samples
-        if load_samples:
-            logging.info("Loading samples")
-
-            # check if need extra parameters for a non-sampling parameter
-            file_parameters, ts = transforms.get_common_cbc_transforms(
-                parameters, fp.variable_params)
-
-            # read samples from file
-            samples = fp.samples_from_cli(opts, extra_opts=extra_opts,
-                                          parameters=parameter)
-
-            # add parameters not included in file
-            samples = transforms.apply_transforms(samples, ts)
-
-        # else do not read samples
-        else:
-            samples = None
-
-        # add results to lists from all input files
-        if len(input_files) > 1:
-            fp_all.append(fp)
-            parameters_all.append(parameters)
-            labels_all.update(ldict)
-            samples_all.append(samples)
-
-        # else only one input file then do not return lists
-        else:
-            fp_all = fp
-            parameters_all = parameters
-            labels_all = ldict
-            samples_all = samples
-
-    return fp_all, parameters_all, labels_all, samples_all
-
-
 
 
 #
@@ -425,3 +209,304 @@ def validate_checkpoint_files(checkpoint_file, backup_file):
         shutil.copy(backup_file, checkpoint_file)
         checkpoint_valid = True
     return checkpoint_valid
+
+
+#
+# =============================================================================
+#
+#                         Command-line Utilities
+#
+# =============================================================================
+#
+class ParseParametersArg(argparse.Action):
+    """Argparse action that will parse parameters and labels from an opton.
+
+    This assumes that the values set on the command line for its assigned
+    argument are strings formatted like ``PARAM[:LABEL]``. When the arguments
+    are parsed, the ``LABEL`` bit is stripped off and added to a dictionary
+    mapping ``PARAM -> LABEL``. This dictionary is stored to the parsed
+    namespace called ``{dest}_labels``, where ``{dest}`` is the argument's
+    ``dest`` setting (by default, this is the same as the option string).
+    Likewise, the argument's ``dest`` in the parsed namespace is updated so
+    that it is just ``PARAM``.
+
+    If no ``LABEL`` is provided, then ``PARAM`` will be used for ``LABEL``.
+
+    If ``LABEL`` is a known parameter in ``pycbc.waveform.parameters``, then
+    the label attribute there will be used in the ``parameter_labels``.
+    Otherwise, ``LABEL`` will be used.
+
+    This action can work on arguments that have ``nargs != 0`` and ``type`` set
+    to ``str``.
+
+    Examples
+    --------
+    Create a parser and add two arguments that use this action (note that the
+    first argument accepts multiple inputs while the second only accepts a
+    single input):
+
+    >>> import argparse
+    >>> parser = argparse.ArgumentParser()
+    >>> parser.add_argument('--parameters', type=str, nargs="+",
+                            action=ParseParametersArg)
+    >>> parser.add_argument('--z-arg', type=str, action=ParseParametersArg)
+
+    Parse a command line that uses these options:
+
+    >>> import shlex
+    >>> cli = "--parameters 'mass1+mass2:mtotal' ra ni --z-arg foo:bar"
+    >>> opts = parser.parse_args(shlex.split(cli))
+    >>> opts.parameters
+    ['mass1+mass2', 'ra', 'ni']
+    >>> opts.parameters_labels
+    {'mass1+mass2': '$M~(\\mathrm{M}_\\odot)$', 'ni': 'ni', 'ra': '$\\alpha$'}
+    >>> opts.z_arg
+    'foo'
+    >>> opts.z_arg_labels
+    {'foo': 'bar'}
+
+    In the above, the first argument to ``--parameters`` was ``mtotal``. Since
+    this is a recognized parameter in ``pycbc.waveform.parameters``, the label
+    dictionary contains the latex string associated with the ``mtotal``
+    parameter. A label was not provided for the second argument, and so ``ra``
+    was used. Since ``ra`` is also a recognized parameter, its associated latex
+    string was used in the labels dictionary. Since ``ni`` and ``bar`` (the
+    label for ``z-arg``) are not recognized parameters, they were just used
+    as-is in the labels dictionaries.
+    """
+    def __init__(self, type=str, nargs=None, **kwargs):
+        # check that type is string
+        if type != str:
+            raise ValueError("the type for this action must be a string")
+        if nargs == 0:
+            raise ValueError("nargs must not be 0 for this action")
+        super(ParseParametersArg, self).__init__(type=type, nargs=nargs,
+                                                 **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        singlearg = isinstance(values, (str, unicode))
+        if singlearg:
+            values = [values]
+        params = []
+        labels = {}
+        for param in values:
+            psplit = param.split(':')
+            if len(psplit) == 2:
+                param, label = psplit
+            else:
+                label = param
+            # try to get the label from waveform.parameters
+            try:
+                label = getattr(_waveform.parameters, label).label
+            except AttributeError:
+                pass
+            labels[param] = label
+            params.append(param)
+        # update the namespace
+        if singlearg:
+            params = params[0]
+        setattr(namespace, self.dest, params)
+        setattr(namespace, '{}_labels'.format(self.dest), labels)
+
+
+class PrintFileParams(argparse.Action):
+    """Argparse action that will load input files and print possible parameters
+    to screen. Once this is done, the program is forced to exit immediately.
+
+    The behvior is similar to --help, except that the input-file is read.
+    """
+    def __init__(self, nargs=0, **kwargs):
+        if nargs != 0:
+            raise ValueError("nargs for this action must be 0")
+        super(PrintParams, self).__init__(nargs=nargs, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        # get the input file(s)
+        input_files = namespace.input_file
+        if input_files is None:
+            raise ValueError("must provide at least one input-file")
+        parameters = []
+        filesbytype = {}
+        fileparsers = {}
+        for fn in input_files:
+            fp = loadfile(fn, 'r')
+            parameters.append(set(fp[fp.samples_group].keys()))
+            try:
+                filesbytype[fp.name].append(fn)
+            except KeyError:
+                filesbytype[fp.name] = [fn]
+                # get any extra options
+                fileparsers[fp.name] = fp.extra_args_parser(add_help=False)
+            fp.close()
+        # print out the extra arguments that may be used
+        outstr = "Additional command-line options that may be provided:\n"
+        for ftype, fparser in fileparsers.items():
+            fnames = ', '.join(filesbytype[ftype])
+            if fparser is None:
+                outstr = "\nFile(s) {} use no additional options.".format(
+                    fnames)
+            else:
+                outstr = "\nThe following are used by file(s) {}:".format(
+                    fnames)
+                fparser.print_help()
+        # now print information about the parameters
+        # take the intersection of all parameters
+        parameters = set.intersection(*parameters)
+        outstr = ("With the given input file(s), the following parameters are "
+                  "available:\n{}\n".format(' '.join(sorted(parameters))))
+        outstr += ("\nThe following pycbc functions may be used on these "
+                   "parameters (see http://pycbc.org/pycbc/latest/html for "
+                   "more details):\n{}\n".format(' '.join(sorted(
+                   FieldArray.functionlib.fget(FieldArray).keys()))))
+        outstr += ("\nThe following numpy functions may be used on these "
+                   "parameters:\n{}\n".format(
+                   ' '.join(sorted(_numpy_function_lib.keys()))))
+        print(outstr, file=sys.stdout)
+        # exit the program
+        parser.exit(0)
+
+
+def add_results_option_group(parser):
+    """Adds the options used to call gwin.io.results_from_cli function
+    to an argument parser.
+    
+    These are options releated to loading the results from a run of
+    gwin, for purposes of plotting and/or creating tables.
+
+    Parameters
+    ----------
+    parser : object
+        ArgumentParser instance.
+    """
+
+    results_reading_group = parser.add_argument_group(
+        "Arguments for loading results. Additional, file-specific arguments "
+        "may also be provided, depending on what input-files are given. See "
+        "print-all-opts for details.")
+
+    # required options
+    results_reading_group.add_argument(
+        "--input-file", type=str, required=True, nargs="+",
+        help="Path to input HDF file(s).")
+    results_reading_group.add_argument(
+        "--parameters", type=str, nargs="+", metavar="PARAM[:LABEL]",
+        action=ParseParametersArg,
+        help="Name of parameters to load. If none provided will load all of "
+             "the model params in the input-file. If provided, the "
+             "parameters can be any of the model params or posteriors in "
+             "the input file, derived parameters from them, or any function "
+             "of them. Syntax for functions is python; any math functions in "
+             "the numpy libary may be used. Can optionally also specify a "
+             "label for each parameter. If no label is provided, will try to "
+             "retrieve a label from the input-file. If no label can be found "
+             "in the input-file, will try to get a label from "
+             "pycbc.waveform.parameters. If no label can be found in either "
+             "place, will just use the parameter. To see all possible "
+             "parameters that may be used, as well as avaiable functions, run "
+             "--print-all-opts, along with one or more input files.")
+    # optionals
+    results_reading_group.add_argument(
+        "--thin-start", type=int, default=None,
+        help="Sample number to start collecting samples to plot. If none "
+             "provided, will use the input file's `thin_start` attribute.")
+    results_reading_group.add_argument(
+        "--thin-interval", type=int, default=None,
+        help="Interval to use for thinning samples. If none provided, will "
+             "use the input file's `thin_interval` attribute.")
+    results_reading_group.add_argument(
+        "--thin-end", type=int, default=None,
+        help="Sample number to stop collecting samples to plot. If none "
+             "provided, will use the input file's `thin_end` attribute.")
+    # advanced help
+    results.reading_group.add_argument(
+        "-H", "--print-all-opts", action=PrintFileParams,
+        help="Based on the provided input-file(s), print all available "
+             "parameters that may be retrieved and all possible functions on "
+             "those parameters. Also print available additional arguments "
+             "that may be passed. This option is like an "
+             "advanced --help: if run, the program will just print the "
+             "information to screen, then exit.")
+    return results_reading_group
+
+
+def results_from_cli(opts, extra_opts=None, load_samples=True):
+    """Loads an inference result file along with any labels associated with it
+    from the command line options.
+
+    Parameters
+    ----------
+    opts : ArgumentParser options
+        The options from the command line.
+    load_samples : bool, optional
+        Load the samples from the file.
+
+    Returns
+    -------
+    fp_all : (list of) BaseInferenceFile type
+        The result file as an hdf file. If more than one input file,
+        then it returns a list.
+    parameters_all : (list of) list
+        List of the parameters to use, parsed from the parameters option.
+        If more than one input file, then it returns a list.
+    labels_all : dict
+        Dictionary of labels to associate with the parameters.
+    samples_all : (list of) FieldArray(s) or None
+        If load_samples, the samples as a FieldArray; otherwise, None.
+        If more than one input file, then it returns a list.
+    """
+
+    # lists for files and samples from all input files
+    fp_all = []
+    parameters_all = []
+    labels_all = {}
+    samples_all = []
+
+    input_files = opts.input_file
+    if isinstance(input_files, str):
+        input_files = [input_files]
+
+    # loop over all input files
+    for input_file in input_files:
+        logging.info("Reading input file %s", input_file)
+
+        # read input file
+        fp = loadfile(input_file, "r")
+
+        # load the samples
+        if load_samples:
+            logging.info("Loading samples")
+
+            # check if need extra parameters for a non-sampling parameter
+            file_parameters, ts = transforms.get_common_cbc_transforms(
+                opts.parameters, fp.variable_params)
+
+            # read samples from file
+            samples = fp.samples_from_cli(opts, extra_opts=extra_opts,
+                                          parameters=file_parameters)
+
+            logging.info("Using {} samples".format(samples.size))
+
+            # add parameters not included in file
+            samples = transforms.apply_transforms(samples, ts)
+
+        # else do not read samples
+        else:
+            samples = None
+
+        # add results to lists from all input files
+        if len(input_files) > 1:
+            fp_all.append(fp)
+            parameters_all.append(opts.parameters)
+            labels_all.update(opts.parameters_labels)
+            samples_all.append(samples)
+
+        # else only one input file then do not return lists
+        else:
+            fp_all = fp
+            parameters_all = opts.parameters
+            labels_all = opts.parameters_labels
+            samples_all = samples
+
+    return fp_all, parameters_all, labels_all, samples_all
+
+

--- a/gwin/io/__init__.py
+++ b/gwin/io/__init__.py
@@ -510,3 +510,35 @@ def results_from_cli(opts, extra_opts=None, load_samples=True):
     return fp_all, parameters_all, labels_all, samples_all
 
 
+def injections_from_cli(opts):
+    """Gets injection parameters from the inference file(s).
+
+    Parameters
+    ----------
+    opts : argparser
+        Argparser object that has the command-line objects to parse.
+
+    Returns
+    -------
+    FieldArray
+        Array of the injection parameters from all of the input files given
+        by ``opts.input_file``.
+    """
+    input_files = opts.input_file
+    if isinstance(input_files, str):
+        input_files = [input_files]
+    injections = None
+    # loop over all input files getting the injection files
+    for input_file in input_files:
+        fp = loadfile(input_file, 'r')
+        these_injs = fp.read_injections()
+        if injections is None:
+            injections = these_injs
+        else:
+            injections = injections.append(these_injs)
+    # check if need extra parameters than parameters stored in injection file
+    _, ts = transforms.get_common_cbc_transforms(opts.parameters,
+                                                 injections.fieldnames)
+    # add parameters not included in injection file
+    injections = transforms.apply_transforms(injections, ts)
+    return injections

--- a/gwin/io/__init__.py
+++ b/gwin/io/__init__.py
@@ -293,7 +293,7 @@ class NoInputFileError(Exception):
     pass
 
 
-class ParseLabelArg(agparse.Action):
+class ParseLabelArg(argparse.Action):
     """Argparse action that will parse arguments that can accept labels.
 
     This assumes that the values set on the command line for its assigned
@@ -310,8 +310,7 @@ class ParseLabelArg(agparse.Action):
     This action can work on arguments that have ``nargs != 0`` and ``type`` set
     to ``str``.
     """
-    def __init__(self, type=str, nargs=None, metavar="VALUE[:LABEL]",
-                 **kwargs):
+    def __init__(self, type=str, nargs=None, **kwargs):
         # check that type is string
         if type != str:
             raise ValueError("the type for this action must be a string")
@@ -388,7 +387,7 @@ class ParseParametersArg(ParseLabelArg):
         super(ParseParametersArg, self).__call__(parser, namespace, values,
                                                  option_string=option_string)
         # try to replace the labels with a label from waveform.parameters
-        labels = getattr(namespace, '{}_labels'.format(self.dest)
+        labels = getattr(namespace, '{}_labels'.format(self.dest))
         for param, label in labels.items():
             try:
                 label = getattr(_waveform.parameters, label).label
@@ -501,8 +500,10 @@ def add_results_option_group(parser):
 
     # required options
     results_reading_group.add_argument(
-        "--input-file", type=str, required=True, nargs="+",
-        help="Path to input HDF file(s).")
+        "--input-file", type=str, required=True, nargs="+", 
+        action=ParseLabelArg, metavar='FILE[:LABEL]',
+        help="Path to input HDF file(s). A label may be specified for each "
+             "input file to use for plots when multiple files are specified.")
     results_reading_group.add_argument(
         "--parameters", type=str, nargs="+", metavar="PARAM[:LABEL]",
         action=ParseParametersArg,

--- a/gwin/io/__init__.py
+++ b/gwin/io/__init__.py
@@ -18,11 +18,14 @@
 """
 
 from __future__ import absolute_import
+from __future__ import print_function
 
 import os
+import sys
 import shutil
 import logging
 import h5py as _h5py
+from pycbc.io.record import FieldArray, _numpy_function_lib
 
 from .emcee import EmceeFile
 from .txt import InferenceTXTFile
@@ -67,6 +70,224 @@ def loadfile(path, mode=None, filetype=None, **kwargs):
             raise IOError("The file appears not to exist. In this case, "
                           "filetype must be provided.")
     return filetypes[filetype](path, mode=mode, **kwargs)
+
+
+#
+# =============================================================================
+#
+#                         CLI Utilities
+#
+# =============================================================================
+#
+
+class PrintFileParams(argparse.Action):
+    """Argparse action that will load input files and print possible parameters
+    to screen. Once this is done, the program is forced to exit immediately.
+
+    The behvior is similar to --help, except that the input-file is read.
+    """
+    def __init__(self, nargs=0, **kwargs):
+        if nargs != 0:
+            raise ValueError("nargs for this action must be 0")
+        super(PrintParams, self).__init__(nargs=nargs, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        # get the input file(s)
+        input_files = namespace.input_file
+        if input_files is None:
+            raise ValueError("must provide at least one input-file")
+        parameters = []
+        filesbytype = {}
+        fileparsers = {}
+        for fn in input_files:
+            fp = loadfile(fn, 'r')
+            parameters.append(set(fp[fp.samples_group].keys()))
+            try:
+                filesbytype[fp.name].append(fn)
+            except KeyError:
+                filesbytype[fp.name] = [fn]
+                # get any extra options
+                fileparsers[fp.name] = fp.extra_args_parser(add_help=False)
+            fp.close()
+        # print out the extra arguments that may be used
+        outstr = "Additional command-line options that may be provided:\n"
+        for ftype, fparser in fileparsers.items():
+            fnames = ', '.join(filesbytype[ftype])
+            if fparser is None:
+                outstr = "\nFile(s) {} use no additional options.".format(
+                    fnames)
+            else:
+                outstr = "\nThe following are used by file(s) {}:".format(
+                    fnames)
+                fparser.print_help()
+        # now print information about the parameters
+        # take the intersection of all parameters
+        parameters = set.intersection(*parameters)
+        outstr = ("With the given input file(s), the following parameters are "
+                  "available:\n{}\n".format(' '.join(sorted(parameters))))
+        outstr += ("\nThe following pycbc functions may be used on these "
+                   "parameters (see http://pycbc.org/pycbc/latest/html for "
+                   "more details):\n{}\n".format(' '.join(sorted(
+                   FieldArray.functionlib.fget(FieldArray).keys()))))
+        outstr += ("\nThe following numpy functions may be used on these "
+                   "parameters:\n{}\n".format(
+                   ' '.join(sorted(_numpy_function_lib.keys()))))
+        print(outstr, file=sys.stdout)
+        # exit the program
+        parser.exit(0)
+
+
+def add_results_option_group(parser):
+    """Adds the options used to call gwin.io.results_from_cli function
+    to an argument parser.
+    
+    These are options releated to loading the results from a run of
+    gwin, for purposes of plotting and/or creating tables.
+
+    Parameters
+    ----------
+    parser : object
+        ArgumentParser instance.
+    """
+
+    results_reading_group = parser.add_argument_group(
+        "Arguments for loading results. Additional, file-specific arguments "
+        "may also be provided, depending on what input-files are given. See "
+        "print-all-opts for details.")
+
+    # required options
+    results_reading_group.add_argument(
+        "--input-file", type=str, required=True, nargs="+",
+        help="Path to input HDF file(s).")
+    results_reading_group.add_argument(
+        "--parameters", type=str, nargs="+", metavar="PARAM[:LABEL]",
+        help="Name of parameters to load. If none provided will load all of "
+             "the model params in the input-file. If provided, the "
+             "parameters can be any of the model params or posteriors in "
+             "the input file, derived parameters from them, or any function "
+             "of them. Syntax for functions is python; any math functions in "
+             "the numpy libary may be used. Can optionally also specify a "
+             "label for each parameter. If no label is provided, will try to "
+             "retrieve a label from the input-file. If no label can be found "
+             "in the input-file, will try to get a label from "
+             "pycbc.waveform.parameters. If no label can be found in either "
+             "place, will just use the parameter. To see all possible "
+             "parameters that may be used, as well as avaiable functions, run "
+             "--print-all-opts, along with one or more input files.")
+    # optionals
+    results_reading_group.add_argument(
+        "--thin-start", type=int, default=None,
+        help="Sample number to start collecting samples to plot. If none "
+             "provided, will use the input file's `thin_start` attribute.")
+    results_reading_group.add_argument(
+        "--thin-interval", type=int, default=None,
+        help="Interval to use for thinning samples. If none provided, will "
+             "use the input file's `thin_interval` attribute.")
+    results_reading_group.add_argument(
+        "--thin-end", type=int, default=None,
+        help="Sample number to stop collecting samples to plot. If none "
+             "provided, will use the input file's `thin_end` attribute.")
+    # advanced help
+    results.reading_group.add_argument(
+        "-H", "--print-all-opts", action=PrintFileParams,
+        help="Based on the provided input-file(s), print all available "
+             "parameters that may be retrieved and all possible functions on "
+             "those parameters. Also print available additional arguments "
+             "that may be passed. This option is like an "
+             "advanced --help: if run, the program will just print the "
+             "information to screen, then exit."
+    return results_reading_group
+
+
+def results_from_cli(opts, extra_opts=None, load_samples=True, **kwargs):
+    """
+    Loads an inference result file along with any labels associated with it
+    from the command line options.
+
+    Parameters
+    ----------
+    opts : ArgumentParser options
+        The options from the command line.
+    load_samples : bool, optional
+        Load the samples from the file.
+
+    **kwargs :
+        All other keyword arguments are passed to the InferenceFile's
+        read_samples function.
+
+    Returns
+    -------
+    fp_all : pycbc.io.InferenceFile
+        The result file as an InferenceFile. If more than one input file,
+        then it returns a list.
+    parameters_all : list
+        List of the parameters to use, parsed from the parameters option.
+        If more than one input file, then it returns a list.
+    labels_all : list
+        List of labels to associate with the parameters. If more than one
+        input file, then it returns a list.
+    samples_all : {None, FieldArray}
+        If load_samples, the samples as a FieldArray; otherwise, None.
+        If more than one input file, then it returns a list.
+    """
+
+    # lists for files and samples from all input files
+    fp_all = []
+    parameters_all = []
+    labels_all = {}
+    samples_all = []
+
+    input_files = opts.input_file
+    if isinstance(input_files, str):
+        input_files = [input_files]
+
+    # loop over all input files
+    for input_file in input_files:
+        logging.info("Reading input file %s", input_file)
+
+        # read input file
+        fp = loadfile(input_file, "r")
+
+        # get parameters and a dict of labels for each parameter
+        parameters, ldict = fp.parameters_from_cli(opts)
+
+        # load the samples
+        if load_samples:
+            logging.info("Loading samples")
+
+            # check if need extra parameters for a non-sampling parameter
+            file_parameters, ts = transforms.get_common_cbc_transforms(
+                parameters, fp.variable_params)
+
+            # read samples from file
+            samples = fp.samples_from_cli(opts, extra_opts=extra_opts,
+                                          parameters=parameter)
+
+            # add parameters not included in file
+            samples = transforms.apply_transforms(samples, ts)
+
+        # else do not read samples
+        else:
+            samples = None
+
+        # add results to lists from all input files
+        if len(input_files) > 1:
+            fp_all.append(fp)
+            parameters_all.append(parameters)
+            labels_all.update(ldict)
+            samples_all.append(samples)
+
+        # else only one input file then do not return lists
+        else:
+            fp_all = fp
+            parameters_all = parameters
+            labels_all = ldict
+            samples_all = samples
+
+    return fp_all, parameters_all, labels_all, samples_all
+
+
+
 
 #
 # =============================================================================

--- a/gwin/io/__init__.py
+++ b/gwin/io/__init__.py
@@ -285,7 +285,7 @@ def get_common_parameters(input_files, collection=None):
     if parameters == []:
         raise ValueError("no common parameters found for collection {} in "
                          "files {}".format(collection, ', '.join(input_files)))
-    return parameters 
+    return parameters
 
 
 class NoInputFileError(Exception):
@@ -338,18 +338,18 @@ class PrintFileParams(argparse.Action):
             fp.close()
         # now print information about the intersection of all parameters
         parameters = get_common_parameters(input_files, collection='all')
-        print("\n"+textwrap.fill("Parameters available with this (these) input "
-                                 "file(s):"), end="\n\n")
+        print("\n"+textwrap.fill("Parameters available with this (these) "
+                                 "input file(s):"), end="\n\n")
         print(textwrap.fill(' '.join(sorted(parameters))),
               end="\n\n")
         # information about the pycbc functions
         pfuncs = sorted(FieldArray.functionlib.fget(FieldArray).keys())
         print(textwrap.fill("Available pycbc functions (see "
                             "http://pycbc.org/pycbc/latest/html for "
-                            "more details):"), end="\n\n") 
+                            "more details):"), end="\n\n")
         print(textwrap.fill(', '.join(pfuncs)), end="\n\n")
         # numpy funcs
-        npfuncs = sorted([name for name,obj in _numpy_function_lib.items()
+        npfuncs = sorted([name for (name, obj) in _numpy_function_lib.items()
                           if isinstance(obj, numpy.ufunc)])
         print(textwrap.fill("Available numpy functions:"),
               end="\n\n")
@@ -486,7 +486,7 @@ class ResultsArgumentParser(argparse.ArgumentParser):
     def add_results_option_group(self):
         """Adds the options used to call gwin.io.results_from_cli function
         to the parser.
-        
+
         These are options releated to loading the results from a run of
         gwin, for purposes of plotting and/or creating tables.
 
@@ -495,45 +495,46 @@ class ResultsArgumentParser(argparse.ArgumentParser):
         """
         results_reading_group = self.add_argument_group(
             title="Arguments for loading results",
-            description="Additional, file-specific arguments "
-            "may also be provided, depending on what input-files are given. See "
+            description="Additional, file-specific arguments may also be "
+            "provided, depending on what input-files are given. See "
             "--file-help for details.")
         results_reading_group.add_argument(
-            "--input-file", type=str, required=True, nargs="+", 
+            "--input-file", type=str, required=True, nargs="+",
             action=ParseLabelArg, metavar='FILE[:LABEL]',
-            help="Path to input HDF file(s). A label may be specified for each "
-                 "input file to use for plots when multiple files are specified.")
+            help="Path to input HDF file(s). A label may be specified for "
+                 "each input file to use for plots when multiple files are "
+                 "specified.")
         # advanced help
         results_reading_group.add_argument(
             "-H", "--file-help",
             action=PrintFileParams, skip_args=self.skip_args,
             help="Based on the provided input-file(s), print all available "
-                 "parameters that may be retrieved and all possible functions on "
-                 "those parameters. Also print available additional arguments "
-                 "that may be passed. This option is like an "
+                 "parameters that may be retrieved and all possible functions "
+                 "on those parameters. Also print available additional "
+                 "arguments that may be passed. This option is like an "
                  "advanced --help: if run, the program will just print the "
                  "information to screen, then exit.")
         results_reading_group.add_argument(
             "--parameters", type=str, nargs="+", metavar="PARAM[:LABEL]",
             action=ParseParametersArg,
-            help="Name of parameters to load. If none provided will load all of "
-                 "the model params in the input-file. If provided, the "
-                 "parameters can be any of the model params or posterior stats "
-                 "(loglikelihood, logprior, etc.) in the input file(s), derived "
-                 "parameters from them, or any function of them. If multiple "
-                 "files are provided, any parameter common to all files may be "
-                 "used. Syntax for functions is python; any math functions in "
-                 "the numpy libary may be used. Can optionally also specify a "
-                 "LABEL for each parameter. If no LABEL is provided, PARAM will "
-                 "used as the LABEL. If LABEL is the same as a parameter in "
-                 "pycbc.waveform.parameters, the label property of that parameter "
-                 "will be used (e.g., if LABEL were 'mchirp' then {} would be "
-                 "used). To see all possible parameters that may be used with the "
-                 "given input file(s), as well as all avaiable functions, run "
-                 "--file-help, along with one or more input files.".format(
-                 _waveform.parameters.mchirp.label))
+            help="Name of parameters to load. If none provided will load all "
+                 "of the model params in the input-file. If provided, the "
+                 "parameters can be any of the model params or posterior "
+                 "stats (loglikelihood, logprior, etc.) in the input file(s), "
+                 "derived parameters from them, or any function of them. If "
+                 "multiple files are provided, any parameter common to all "
+                 "files may be used. Syntax for functions is python; any math "
+                 "functions in the numpy libary may be used. Can optionally "
+                 "also specify a LABEL for each parameter. If no LABEL is "
+                 "provided, PARAM will used as the LABEL. If LABEL is the "
+                 "same as a parameter in pycbc.waveform.parameters, the label "
+                 "property of that parameter will be used (e.g., if LABEL "
+                 "were 'mchirp' then {} would be used). To see all possible "
+                 "parameters that may be used with the given input file(s), "
+                 "as well as all avaiable functions, run --file-help, along "
+                 "with one or more input files.".format(
+                    _waveform.parameters.mchirp.label))
         return results_reading_group
-
 
 
 def results_from_cli(opts, load_samples=True):

--- a/gwin/io/base_hdf.py
+++ b/gwin/io/base_hdf.py
@@ -41,6 +41,7 @@ from pycbc.io import FieldArray
 from pycbc.types import FrequencySeries
 from pycbc.waveform import parameters as wfparams
 
+from ..option_utils import parse_parameters_opt
 
 class BaseInferenceFile(h5py.File):
     """Base class for all inference hdf files.
@@ -209,6 +210,43 @@ class BaseInferenceFile(h5py.File):
             Name of the file to write to.
         \**kwargs :
             Any other keyword args the sampler needs to write the posterior.
+        """
+        pass
+
+    def parameters_from_cli(self, opts):
+        """Parses the --parameters option in the given command-line options.
+
+        Parameters
+        ----------
+        opts : argparse.Namespace
+            Options parsed by argparse (i.e., the thing returned by
+            ArgumentParser.parse_args).
+
+        Returns
+        -------
+        parameters : list
+            List of parameters to load. If --parameters were not provided,
+            defaults to the ``variable_params``.
+        labels : dict
+            Dictionary mapping parameter names to labels.
+        """
+        parameters = (self.variable_params if opts.parameters is None
+                      else opts.parameters)
+        return parse_parameters_opt(parameters)
+
+    @abstractmethod
+    def samples_from_cli(self, opts, parameters=None):
+        """This should load samples using the given command-line options.
+        """
+        pass
+
+    @staticmethod
+    def extra_args_parser(parser=None, **kwargs):
+        """Provides a parser that can be used to parse sampler-specific command
+        line options for loading samples.
+
+        This is optional. Inheriting classes may override this if they want to
+        implement their own options.
         """
         pass
 

--- a/gwin/io/base_hdf.py
+++ b/gwin/io/base_hdf.py
@@ -41,7 +41,7 @@ from pycbc.io import FieldArray
 from pycbc.types import FrequencySeries
 from pycbc.waveform import parameters as wfparams
 
-from ..option_utils import parse_parameters_opt
+from .cli import parse_parameters_opt
 
 class BaseInferenceFile(h5py.File):
     """Base class for all inference hdf files.
@@ -671,27 +671,27 @@ class BaseInferenceFile(h5py.File):
                 other.attrs['thin_end'] = None
         return other
 
+    @classmethod
+    def write_kwargs_to_attrs(cls, attrs, **kwargs):
+        """Writes the given keywords to the given ``attrs``.
 
-def write_kwargs_to_hdf_attrs(attrs, **kwargs):
-    """Writes the given keywords to the given ``attrs``.
+        If any keyword argument points to a dict, the keyword will point to a
+        list of the dict's keys. Each key is then written to the attrs with its
+        corresponding value.
 
-    If any keyword argument points to a dict, the keyword will point to a
-    list of the dict's keys. Each key is then written to the attrs with its
-    corresponding value.
-
-    Parameters
-    ----------
-    attrs : an HDF attrs
-        Can be either the ``attrs`` of the hdf file, or any group in a file.
-    \**kwargs :
-        The keywords to write.
-    """
-    for arg, val in kwargs.items():
-        if val is None:
-            val = str(None)
-        if isinstance(val, dict):
-            attrs[arg] = val.keys()
-            # just call self again with the dict as kwargs
-            write_kwargs_to_hdf_attrs(attrs, **val)
-        else:
-            attrs[arg] = val
+        Parameters
+        ----------
+        attrs : an HDF attrs
+            The ``attrs`` of an hdf file or a group in an hdf file.
+        \**kwargs :
+            The keywords to write.
+        """
+        for arg, val in kwargs.items():
+            if val is None:
+                val = str(None)
+            if isinstance(val, dict):
+                attrs[arg] = val.keys()
+                # just call self again with the dict as kwargs
+                cls.write_kwargs_to_attrs(attrs, **val)
+            else:
+                attrs[arg] = val

--- a/gwin/io/base_hdf.py
+++ b/gwin/io/base_hdf.py
@@ -292,7 +292,7 @@ class BaseInferenceFile(h5py.File):
 
     def samples_from_cli(self, opts, parameters=None, **kwargs):
         """Reads samples from the given command-line options.
-        
+
         Parameters
         ----------
         opts : argparse Namespace

--- a/gwin/io/base_hdf.py
+++ b/gwin/io/base_hdf.py
@@ -431,7 +431,6 @@ class BaseInferenceFile(h5py.File):
         if group is None:
             group = subgroup
         else:
-            print group, subgroup
             group = '/'.join([group, subgroup])
         for ifo in psds:
             self[group.format(ifo=ifo)] = psds[ifo]
@@ -464,7 +463,7 @@ class BaseInferenceFile(h5py.File):
         injset = InjectionSet(self.filename, hdf_group=self.injections_group)
         injections = injset.table.view(FieldArray)
         # close the new open filehandler to self
-        injset.filehandler.close()
+        injset._injhandler.filehandler.close()
         return injections
 
     def write_command_line(self):

--- a/gwin/io/base_mcmc.py
+++ b/gwin/io/base_mcmc.py
@@ -152,7 +152,7 @@ class MCMCIO(object):
     def extra_args_parser(parser=None, skip_args=None, **kwargs):
         """Create a parser to parse sampler-specific arguments for loading
         samples.
-        
+
         Parameters
         ----------
         parser : argparse.ArgumentParser, optional
@@ -185,20 +185,22 @@ class MCMCIO(object):
         if 'thin-start' not in skip_args:
             act = parser.add_argument(
                 "--thin-start", type=int, default=None,
-                help="Sample number to start collecting samples to plot. If none "
-                     "provided, will use the input file's `thin_start` attribute.")
+                help="Sample number to start collecting samples to plot. If "
+                     "none provided, will use the input file's `thin_start` "
+                     "attribute.")
             actions.append(act)
         if 'thin-interval' not in skip_args:
             act = parser.add_argument(
                 "--thin-interval", type=int, default=None,
-                help="Interval to use for thinning samples. If none provided, will "
-                     "use the input file's `thin_interval` attribute.")
+                help="Interval to use for thinning samples. If none provided, "
+                     "will use the input file's `thin_interval` attribute.")
             actions.append(act)
         if 'thin-end' not in skip_args:
             act = parser.add_argument(
                 "--thin-end", type=int, default=None,
-                help="Sample number to stop collecting samples to plot. If none "
-                     "provided, will use the input file's `thin_end` attribute.")
+                help="Sample number to stop collecting samples to plot. If "
+                     "none provided, will use the input file's `thin_end` "
+                     "attribute.")
             actions.append(act)
         if 'iteration' not in skip_args:
             act = parser.add_argument(

--- a/gwin/io/base_mcmc.py
+++ b/gwin/io/base_mcmc.py
@@ -149,53 +149,73 @@ class MCMCIO(object):
         return arrays
 
     @staticmethod
-    def extra_args_parser(parser=None, **kwargs):
-        """Parser to parse sampler-specific arguments for loading samples.
+    def extra_args_parser(parser=None, skip_args=None, **kwargs):
+        """Create a parser to parse sampler-specific arguments for loading
+        samples.
         
         Parameters
         ----------
         parser : argparse.ArgumentParser, optional
             Instead of creating a parser, add arguments to the given one. If
             none provided, will create one.
+        skip_args : list, optional
+            Don't parse the given options. Options should be given as the
+            option string, minus the '--'. For example,
+            ``skip_args=['iteration']`` would cause the ``--iteration``
+            argument not to be included.
         \**kwargs :
             All other keyword arguments are passed to the parser that is
             created.
+
+        Returns
+        -------
+        parser : argparse.ArgumentParser
+            An argument parser with th extra arguments added.
+        actions : list of argparse.Action
+            A list of the actions that were added.
         """
         if parser is None:
             parser = argparse.ArgumentParser(**kwargs)
         elif kwargs:
             raise ValueError("No other keyword arguments should be provded if "
                              "a parser is provided.")
-        parser.add_argument("--iteration", type=int, default=None,
-                            help="Only retrieve the given iteration. To load "
-                                 "the last n-th sampe use -n, e.g., -1 will "
-                                 "load the last iteration. This overrides "
-                                  "the thin-start/interval/end options.")
-        parser.add_argument("--walkers", type=int, nargs="+", default=None,
-                            help="Only retrieve samples from the listed "
-                                 "walkers. Default is to retrieve from all "
-                                 "walkers.")
-        return parser
-
-    def samples_from_cli(self, opts, extra_opts=None, parameters=None):
-        """Reads samples from the given command-line options."""
-        if parameters is None and opts.parameters is None:
-            parameters = self.variable_args
-        elif parameters is None:
-            parameters = opts.parameters
-        # parse the extra-opts
-        if extra_opts is not None:
-            opts, unknown = self.extra_args_parser().parse_args(extra_opts,
-                                                                namespace=opts)
-            if unknown:
-                logging.warn("File {} does not understand options {}; "
-                             "ignoring.".format(self.filename,
-                                                ' '.join(unknown)))
-        return self.read_samples(parameters, thin_start=opts.thin_start,
-                                 thin_interval=opts.thin_interval,
-                                 thin_end=opts.thin_end,
-                                 iteration=opts.iteration,
-                                 walkers=opts.walkers)
+        if skip_args is None:
+            skip_args = []
+        actions = []
+        if 'thin-start' not in skip_args:
+            act = parser.add_argument(
+                "--thin-start", type=int, default=None,
+                help="Sample number to start collecting samples to plot. If none "
+                     "provided, will use the input file's `thin_start` attribute.")
+            actions.append(act)
+        if 'thin-interval' not in skip_args:
+            act = parser.add_argument(
+                "--thin-interval", type=int, default=None,
+                help="Interval to use for thinning samples. If none provided, will "
+                     "use the input file's `thin_interval` attribute.")
+            actions.append(act)
+        if 'thin-end' not in skip_args:
+            act = parser.add_argument(
+                "--thin-end", type=int, default=None,
+                help="Sample number to stop collecting samples to plot. If none "
+                     "provided, will use the input file's `thin_end` attribute.")
+            actions.append(act)
+        if 'iteration' not in skip_args:
+            act = parser.add_argument(
+                "--iteration", type=int, default=None,
+                help="Only retrieve the given iteration. To load "
+                     "the last n-th sampe use -n, e.g., -1 will "
+                     "load the last iteration. This overrides "
+                     "the thin-start/interval/end options.")
+            actions.append(act)
+        if 'walkers' not in skip_args:
+            act = parser.add_argument(
+                "--walkers", type=int, nargs="+", default=None,
+                help="Only retrieve samples from the listed "
+                     "walkers. Default is to retrieve from all "
+                     "walkers.")
+            actions.append(act)
+        return parser, actions
 
     def write_resume_point(self):
         """Keeps a list of the number of iterations that were in a file when a

--- a/gwin/io/base_mcmc.py
+++ b/gwin/io/base_mcmc.py
@@ -148,6 +148,53 @@ class MCMCIO(object):
             arrays[name] = arr
         return arrays
 
+    @staticmethod
+    def extra_args_parser(parser=None, **kwargs):
+        """Parser to parse sampler-specific arguments for loading samples.
+        
+        Parameters
+        ----------
+        parser : argparse.ArgumentParser, optional
+            Instead of creating a parser, add arguments to the given one. If
+            none provided, will create one.
+        \**kwargs :
+            All other keyword arguments are passed to the parser that is
+            created.
+        """
+        if parser is None:
+            parser = argparse.ArgumentParser(**kwargs)
+        elif kwargs:
+            raise ValueError("No other keyword arguments should be provded if "
+                             "a parser is provided.")
+        parser.add_argument("--iteration", type=int, default=None,
+                            help="Only retrieve the given iteration. To load "
+                                 "the last n-th sampe use -n, e.g., -1 will "
+                                 "load the last iteration. This overrides "
+                                  "the thin-start/interval/end options.")
+        parser.add_argument("--walkers", type=int, nargs="+", default=None,
+                            help="Only retrieve samples from the listed "
+                                 "walkers. Default is to retrieve from all "
+                                 "walkers.")
+        return parser
+
+    def samples_from_cli(self, opts, extra_opts=None, parameters=None):
+        """Reads samples from the given command-line options."""
+        if parameters is None:
+            parameters, _ = self.parameters_from_cli(opts)
+        # parse the extra-opts
+        if extra_opts is not None:
+            opts, unknown = self.extra_args_parser().parse_args(extra_opts,
+                                                                namespace=opts)
+            if unknown:
+                logging.warn("File {} does not understand options {}; "
+                             "ignoring.".format(self.filename,
+                                                ' '.join(unknown))
+        return self.read_samples(parameters, thin_start=opts.thin_start,
+                                 thin_interval=opts.thin_interval,
+                                 thin_end=opts.thin_end,
+                                 iteration=opts.iteration,
+                                 walkers=opts.walkers)
+
     def write_resume_point(self):
         """Keeps a list of the number of iterations that were in a file when a
         run was resumed from a checkpoint."""

--- a/gwin/io/base_mcmc.py
+++ b/gwin/io/base_mcmc.py
@@ -178,8 +178,10 @@ class MCMCIO(object):
 
     def samples_from_cli(self, opts, extra_opts=None, parameters=None):
         """Reads samples from the given command-line options."""
-        if parameters is None:
-            parameters, _ = self.parameters_from_cli(opts)
+        if parameters is None and opts.parameters is None:
+            parameters = self.variable_args
+        elif parameters is None:
+            parameters = opts.parameters
         # parse the extra-opts
         if extra_opts is not None:
             opts, unknown = self.extra_args_parser().parse_args(extra_opts,

--- a/gwin/io/base_mcmc.py
+++ b/gwin/io/base_mcmc.py
@@ -29,7 +29,6 @@ from __future__ import absolute_import
 from abc import (ABCMeta, abstractmethod)
 
 import numpy
-from .base_hdf import write_kwargs_to_hdf_attrs
 
 
 class MCMCIO(object):
@@ -188,7 +187,7 @@ class MCMCIO(object):
             if unknown:
                 logging.warn("File {} does not understand options {}; "
                              "ignoring.".format(self.filename,
-                                                ' '.join(unknown))
+                                                ' '.join(unknown)))
         return self.read_samples(parameters, thin_start=opts.thin_start,
                                  thin_interval=opts.thin_interval,
                                  thin_end=opts.thin_end,
@@ -295,4 +294,4 @@ class MCMCIO(object):
             except KeyError:
                 group.create_group(key)
                 attrs = group[key].attrs
-            write_kwargs_to_hdf_attrs(attrs, **burn_in.burn_in_data[tst])
+            self.write_kwargs_to_attrs(attrs, **burn_in.burn_in_data[tst])

--- a/gwin/io/base_mcmc.py
+++ b/gwin/io/base_mcmc.py
@@ -29,6 +29,7 @@ from __future__ import absolute_import
 from abc import (ABCMeta, abstractmethod)
 
 import numpy
+import argparse
 
 
 class MCMCIO(object):

--- a/gwin/models/base.py
+++ b/gwin/models/base.py
@@ -34,7 +34,6 @@ from pycbc import (transforms, distributions)
 from pycbc.io import FieldArray
 from pycbc.workflow import ConfigParser
 
-from gwin.io.base_hdf import write_kwargs_to_hdf_attrs
 
 #
 # =============================================================================
@@ -755,4 +754,4 @@ class BaseModel(object):
         fp.attrs['model'] = self.name
         fp.attrs['variable_params'] = list(self.variable_params)
         fp.attrs['sampling_params'] = list(self.sampling_params)
-        write_kwargs_to_hdf_attrs(fp.attrs, static_params=self.static_params)
+        fp.write_kwargs_to_attrs(fp.attrs, static_params=self.static_params)

--- a/gwin/option_utils.py
+++ b/gwin/option_utils.py
@@ -208,7 +208,7 @@ class ParseLabelArg(argparse.Action):
         if nargs == 0:
             raise ValueError("nargs must not be 0 for this action")
         super(ParseLabelArg, self).__init__(type=type, nargs=nargs,
-                                                 **kwargs)
+                                            **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
         singlearg = isinstance(values, (str, unicode))

--- a/gwin/results/scatter_histograms.py
+++ b/gwin/results/scatter_histograms.py
@@ -341,7 +341,7 @@ def create_marginalized_hist(ax, values, label, percentiles=None,
     else:
         orientation = 'vertical'
     ax.hist(values, bins=50, histtype=htype, orientation=orientation,
-            facecolor=fillcolor, edgecolor=color, lw=2, normed=True)
+            facecolor=fillcolor, edgecolor=color, lw=2, density=True)
     if percentiles is None:
         percentiles = [5., 50., 95.]
     values = numpy.percentile(values, percentiles)

--- a/gwin/results/scatter_histograms.py
+++ b/gwin/results/scatter_histograms.py
@@ -496,8 +496,9 @@ def create_multidim_plot(parameters, samples, labels=None,
         Names of the variables to be plotted.
     samples : FieldArray
         A field array of the samples to plot.
-    labels: {None, list}, optional
-        A list of names for the parameters.
+    labels: dict, optional
+        A dictionary mapping parameters to labels. If none provided, will just
+        use the parameter strings as the labels.
     mins : {None, dict}, optional
         Minimum value for the axis of each variable in `parameters`.
         If None, it will use the minimum of the corresponding variable in
@@ -563,10 +564,7 @@ def create_multidim_plot(parameters, samples, labels=None,
         `{('param1', 'param2'): (pyplot.axes, row index, column index)}`
     """
     if labels is None:
-        labels = [p for p in parameters]
-    # turn labels into a dict for easier access
-    labels = dict(zip(parameters, labels))
-
+        labels = {p: p for p in parameters}
     # set up the figure with a grid of axes
     # if only plotting 2 parameters, make the marginal plots smaller
     nparams = len(parameters)


### PR DESCRIPTION
Updates`read_samples_from_cli`, `gwin_plot_posterior` and `gwin_plot_movie` (other plotting codes will be addressed in another PR) to handle new sampler files. Also provides a way to print off a more informative help, based on the given input files.

Sampler-specific options are now added by to the argument parser by the sampler's IO class. Specifically, `--iteration`, `--thin-start`, `--thin-interval`, `--thin-end`, `--walkers` are added by the `BaseMCMCIO` class, since these are all options unique to MCMC (and presumably would not be understood by a nested sampler file). Likewise, once support is added for `emcee_pt` (separate PR), it will add a `--temps` argument.

These sampler-specific options do not appear when you run the program's `--help/-h`, but can be viewed by providing an input file and running `--file-help/-H`. For example, running `-h` on :
```
$ gwin_plot_posterior -h
usage: gwin_plot_posterior [-h] [--input-file FILE[:LABEL] [FILE[:LABEL] ...]]
                           [-H] [--parameters PARAM[:LABEL] [PARAM[:LABEL]
                           ...]] [--version] [--output-file OUTPUT_FILE]
                           [--verbose] [--plot-marginal]
                           [--marginal-percentiles MARGINAL_PERCENTILES [MARGINAL_PERCENTILES ...]]
                           [--plot-scatter] [--plot-density] [--plot-contours]
                           [--contour-percentiles CONTOUR_PERCENTILES [CONTOUR_PERCENTILES ...]]
                           [--mins PARAM:VAL [PARAM:VAL ...]]
                           [--maxs PARAM:VAL [PARAM:VAL ...]]
                           [--expected-parameters PARAM:VAL [PARAM:VAL ...]]
                           [--expected-parameters-color EXPECTED_PARAMETERS_COLOR]
                           [--plot-injection-parameters] [--z-arg Z_ARG]
                           [--vmin VMIN] [--vmax VMAX]
                           [--scatter-cmap SCATTER_CMAP]
                           [--density-cmap DENSITY_CMAP]
                           [--contour-color CONTOUR_COLOR] [--use-kombine-kde]

optional arguments:
  -h, --help            show this help message and exit
  --version             Prints version information.
  --output-file OUTPUT_FILE
                        Output plot path.
  --verbose             Be verbose

Arguments for loading results:
  Additional, file-specific arguments may also be provided, depending on
  what input-files are given. See --file-help for details.

  --input-file FILE[:LABEL] [FILE[:LABEL] ...]
                        Path to input HDF file(s). A label may be specified
                        for each input file to use for plots when multiple
                        files are specified.
  -H, --file-help       Based on the provided input-file(s), print all
                        available parameters that may be retrieved and all
                        possible functions on those parameters. Also print
                        available additional arguments that may be passed.
                        This option is like an advanced --help: if run, the
                        program will just print the information to screen,
                        then exit.
  --parameters PARAM[:LABEL] [PARAM[:LABEL] ...]
                        Name of parameters to load. If none provided will load
                        all of the model params in the input-file. If
                        provided, the parameters can be any of the model
                        params or posterior stats (loglikelihood, logprior,
                        etc.) in the input file(s), derived parameters from
                        them, or any function of them. If multiple files are
                        provided, any parameter common to all files may be
                        used. Syntax for functions is python; any math
                        functions in the numpy libary may be used. Can
                        optionally also specify a LABEL for each parameter. If
                        no LABEL is provided, PARAM will used as the LABEL. If
                        LABEL is the same as a parameter in
                        pycbc.waveform.parameters, the label property of that
                        parameter will be used (e.g., if LABEL were 'mchirp'
                        then $\mathcal{M}~(\mathrm{M}_\odot)$ would be used).
                        To see all possible parameters that may be used with
                        the given input file(s), as well as all avaiable
                        functions, run --file-help, along with one or more
                        input files.

Options for what plots to create and their formats.:
  --plot-marginal       Plot 1D marginalized distributions on the diagonal
                        axes.
[etc]
```
The thin options are not visible. Running `-H` with a samples file that was produced by `emcee` gives:
```
$ gwin_plot_posterior -H --input-file normal2d.hdf

Parameters available with this (these) input file(s):

logjacobian loglikelihood logprior x y

Available pycbc functions (see http://pycbc.org/pycbc/latest/html for
more details):

cartesian_to_spherical, cartesian_to_spherical_azimuthal,
cartesian_to_spherical_polar, cartesian_to_spherical_rho, chi_a,
chi_eff, chi_eff_from_spherical, chi_p, chi_p_from_spherical,
chi_p_from_xi1_xi2, chi_perp_from_mass1_mass2_xi2,
chi_perp_from_spinx_spiny, chirp_distance, det_tc,
dquadmon_from_lambda, eta_from_mass1_mass2, eta_from_q,
eta_from_tau0_tau3, final_mass_from_f0_tau, final_spin_from_f0_tau,
freq_from_final_mass_spin, invq_from_mass1_mass2, lambda_tilde,
mass1_from_mass2_eta, mass1_from_mchirp_eta, mass1_from_mchirp_q,
mass1_from_mtotal_eta, mass1_from_mtotal_q, mass1_from_tau0_tau3,
mass2_from_mass1_eta, mass2_from_mchirp_eta, mass2_from_mchirp_mass1,
mass2_from_mchirp_q, mass2_from_mtotal_eta, mass2_from_mtotal_q,
mass2_from_tau0_tau3, mass_from_knownmass_eta,
mchirp_from_mass1_mass2, mtotal_from_mass1_mass2,
mtotal_from_mchirp_eta, mtotal_from_tau0_tau3,
nltides_gw_phase_diff_isco, optimal_dec_from_detector,
optimal_ra_from_detector, phi1_from_phi_a_phi_s,
phi2_from_phi_a_phi_s, phi_a, phi_from_spinx_spiny, phi_s,
primary_mass, primary_spin, primary_xi, q_from_mass1_mass2, redshift,
secondary_mass, secondary_spin, secondary_xi, snr_from_loglr,
spherical_to_cartesian, spin1x_from_xi1_phi_a_phi_s,
spin1y_from_xi1_phi_a_phi_s, spin1z_from_mass1_mass2_chi_eff_chi_a,
spin2x_from_mass1_mass2_xi2_phi_a_phi_s,
spin2y_from_mass1_mass2_xi2_phi_a_phi_s,
spin2z_from_mass1_mass2_chi_eff_chi_a, tau0_from_mass1_mass2,
tau0_from_mtotal_eta, tau3_from_mass1_mass2, tau3_from_mtotal_eta,
tau_from_final_mass_spin, xi1_from_spin1x_spin1y,
xi2_from_mass1_mass2_spin2x_spin2y

Available numpy functions:

abs, absolute, add, arccos, arccosh, arcsin, arcsinh, arctan, arctan2,
arctanh, bitwise_and, bitwise_not, bitwise_or, bitwise_xor, cbrt,
ceil, conj, conjugate, copysign, cos, cosh, deg2rad, degrees, divide,
divmod, equal, exp, exp2, expm1, fabs, float_power, floor,
floor_divide, fmax, fmin, fmod, frexp, gcd, greater, greater_equal,
heaviside, hypot, invert, isfinite, isinf, isnan, isnat, lcm, ldexp,
left_shift, less, less_equal, log, log10, log1p, log2, logaddexp,
logaddexp2, logical_and, logical_not, logical_or, logical_xor,
maximum, minimum, mod, modf, multiply, negative, nextafter, not_equal,
positive, power, rad2deg, radians, reciprocal, remainder, right_shift,
rint, sign, signbit, sin, sinh, spacing, sqrt, square, subtract, tan,
tanh, true_divide, trunc

Recognized constants:

e euler_gamma inf nan pi

Python arthimetic (+ - * / // ** %), binary (&, |, etc.), and
comparison (>, <, >=, etc.) operators may also be used.


The following are additional command-line options that may be
provided, along with the input files that understand them:

usage: normal2d.hdf

optional arguments:
  --thin-start THIN_START
                        Sample number to start collecting samples to plot. If
                        none provided, will use the input file's `thin_start`
                        attribute.
  --thin-interval THIN_INTERVAL
                        Interval to use for thinning samples. If none
                        provided, will use the input file's `thin_interval`
                        attribute.
  --thin-end THIN_END   Sample number to stop collecting samples to plot. If
                        none provided, will use the input file's `thin_end`
                        attribute.
  --iteration ITERATION
                        Only retrieve the given iteration. To load the last
                        n-th sampe use -n, e.g., -1 will load the last
                        iteration. This overrides the thin-start/interval/end
                        options.
  --walkers WALKERS [WALKERS ...]
                        Only retrieve samples from the listed walkers. Default
                        is to retrieve from all walkers.
```
The options are shown, along with the parameters that may be plotted and functions that may be used.

This also allows for one or more of these options to be turned off. For example, `gwin_plot_movie` does not accept the `thin-` and iterations arguments, since these are figured out internally. These options are therefore turned off:
```
$ gwin_plot_movie -H --input-file normal2d.hdf 

<snip>

The following are additional command-line options that may be
provided, along with the input files that understand them:

usage: normal2d.hdf

optional arguments:
  --walkers WALKERS [WALKERS ...]
                        Only retrieve samples from the listed walkers. Default
                        is to retrieve from all walkers.
```
If no `--input-file` is given when `--file-help/-H` is run, then an error is raised.